### PR TITLE
Adding toolbar at other tabs

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -832,6 +832,7 @@ export class SurveyCreator implements ISurveyObjectEditorOptions {
         action: () => this.showDesigner()
       });
       if (this.showJSONEditorTab) {
+        this.jsonEditor.toolbarItems = this.toolbarItems;
         this.tabs.push({
           name: "editor",
           title: this.getLocString("ed.jsonEditor"),
@@ -859,6 +860,7 @@ export class SurveyCreator implements ISurveyObjectEditorOptions {
         });
       }
       if (this.showTranslationTab) {
+        this.translation.toolbarItems = this.toolbarItems;
         this.tabs.push({
           name: "translation",
           title: this.getLocString("ed.translation"),

--- a/src/surveyJSONEditor.ts
+++ b/src/surveyJSONEditor.ts
@@ -1,9 +1,11 @@
 import * as ko from "knockout";
 import { SurveyTextWorker } from "./textWorker";
+import { IToolbarItem } from "./editor";
 import * as Survey from "survey-knockout";
 
 export class SurveyJSONEditor {
   public static updateTextTimeout: number = 1000;
+  public toolbarItems = ko.observableArray<IToolbarItem>();
 
   private isProcessingImmediately: boolean = false;
   private aceEditor: AceAjax.Editor;

--- a/src/templates/jsoneditor.html
+++ b/src/templates/jsoneditor.html
@@ -7,5 +7,17 @@
         </div>
         <!-- /ko  -->
     </div>
+    <div class="svd_toolbar">
+    <!-- ko foreach: toolbarItems -->
+    <span
+        tabindex="0"
+        class="svd_action"
+        data-bind="css: $data.css, visible: visible, attr: { id: id }"
+    >
+        <!-- ko template: { name: $data.template || 'svd-toolbar-button', data: $data.data || $data } -->
+        <!-- /ko -->
+    </span>
+    <!-- /ko -->
+    </div>
     <div id="surveyjsJSONEditor" class="svd_json_editor"></div>
 </script>

--- a/src/templates/translation.html
+++ b/src/templates/translation.html
@@ -1,5 +1,17 @@
 <script type="text/html" id="translation">
     <div class="form-group svd-translation-tab">
+        <div class="svd_toolbar">
+        <!-- ko foreach: toolbarItems -->
+        <span
+            tabindex="0"
+            class="svd_action"
+            data-bind="css: $data.css, visible: visible, attr: { id: id }"
+        >
+            <!-- ko template: { name: $data.template || 'svd-toolbar-button', data: $data.data || $data } -->
+            <!-- /ko -->
+        </span>
+        <!-- /ko -->
+        </div>
         <div class="form-group svd-language-select">
         <div class="svd_custom_select svd-light-bg-color svd-light-border-color"> 
             <select onmousewheel="return false;" data-bind="options: koAvailableLanguages, value: koSelectedLanguageToAdd, optionsText:'text', optionsCaption: $data.selectLanguageOptionsCaption"></select>

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -3,6 +3,7 @@ import * as Survey from "survey-knockout";
 import { editorLocalization } from "./editorLocalization";
 import { ArrayIterator } from "lodash";
 import { TSImportEqualsDeclaration } from "babel-types";
+import { IToolbarItem } from "./editor";
 
 export class TranslationItemBase {
   constructor(public name: string) {}
@@ -277,6 +278,7 @@ export class Translation implements ITranslationLocales {
   public importFinishedCallback: () => void;
   public availableTranlationsChangedCallback: () => void;
   public tranlationChangedCallback: (locale: string, name: string, value: string, context: any) => void;
+  public toolbarItems = ko.observableArray<IToolbarItem>();
   private rootValue: TranslationGroup;
   private surveyValue: Survey.Survey;
   constructor(survey: Survey.Survey, showAllStrings: boolean = false) {


### PR DESCRIPTION
This will enable the user to have the toolbar available at the JSONEditor and translation tab. Since these toolbar items has a visible property, it'`s seem not be a problem to expose them to other tabs.