### PR TITLE
External CSV parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "knockout": "^3.5.0",
+    "papaparse": "^5.2.0",
     "rmodal": "1.0.31",
     "sortablejs": "1.6.1",
     "survey-knockout": "^1.7.1"
@@ -34,6 +35,7 @@
     "@types/bootstrap": "3.3.32",
     "@types/node": "7.0.4",
     "@types/qunit": "2.0.31",
+    "@types/papaparse": "^5.0.3",
     "ace-builds": "1.2.2",
     "ajv": "4.11.2",
     "babel-core": "6.22.1",

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -525,7 +525,7 @@ export class Translation implements ITranslationLocales {
     return editorLocalization.getString("ed.translationImportFromSCVButton");
   }
   public exportToCSV(): string {
-    var res = [];
+    let res = [];
     let headerRow = [];
     let visibleLocales = this.getVisibleLocales();
     headerRow.push('description ↓ - language →');
@@ -626,7 +626,9 @@ export class Translation implements ITranslationLocales {
   }
 
   private getVisibleLocales(): Array<string> {
-    return this.koLocales().filter((locale) => locale.koVisible());
+    return this.koLocales()
+        .filter(locale => locale.koVisible())
+        .map(locale => locale.locale);
   }
 
   private fillItemsHash(

--- a/tests/translationtest.ts
+++ b/tests/translationtest.ts
@@ -436,7 +436,7 @@ QUnit.test("Export to csv", function(assert) {
     "|default|de\n" +
     "survey.page1.question1.title|question1_1|\n" +
     "survey.page1.question1.col1.title|col1 en1|col1 de1";
-  translation.importFromCSV(translatedStr);
+  translation.importFromNestedArray(translatedStr);
   var question = <Survey.QuestionMatrixDropdown>(
     survey.getQuestionByName("question1")
   );


### PR DESCRIPTION
This PR cleans up the translation module:

- Use PapaParse, a library dedicated to parsing CSVs.
- Use modern JS / TS since it is compiled to a target JS version anyway.
- Fixes #777 

