### PR TITLE
#3465 - remove max-width from creator pages

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/designer.scss
+++ b/packages/survey-creator-core/src/components/tabs/designer.scss
@@ -16,7 +16,7 @@ svc-tab-designer {
 
 .svc-tab-designer {
   .sd-container-modern {
-    max-width: calcSize(102);
+    //max-width: calcSize(102);
     width: 100%;
     margin-left: auto;
     margin-right: auto;

--- a/packages/survey-creator-core/src/survey-designer-theme/blocks/sd-page.scss
+++ b/packages/survey-creator-core/src/survey-designer-theme/blocks/sd-page.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: flex-start;
   padding: calcSize(5) calcSize(2) calcSize(2);
-  max-width: calcSize(120);
+  //max-width: calcSize(120);
   width: 100%;
   margin: auto;
   box-sizing: border-box;


### PR DESCRIPTION
I did the first step to implement this option - just removed maxWith for default.
It looks pretty ok on 1920x1080
![image](https://user-images.githubusercontent.com/29385489/136904724-46cf56b5-82e6-4a32-bfdf-15d2f0fac466.png)

Seems like it could be good solution to merge this PR without option implementing and then continue work on this issue in nearest future.