### PR TITLE
v2: DnD: while dragging selected element the "selection"(orange border) should go to the shortcut and moved to element after drag 

### DIFF
--- a/packages/survey-creator-core/src/components/question.scss
+++ b/packages/survey-creator-core/src/components/question.scss
@@ -82,6 +82,26 @@ svc-question {
   }
 }
 
+.svc-dragged-element-shortcut {
+  height: 24px;
+  min-width: 100px;
+  border-radius: 36px;
+  background-color: white;
+  padding: 16px;
+  cursor: grabbing;
+  position: absolute;
+  z-index: 1000;
+  box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.1);
+  font-family: 'Open Sans';
+  font-size: 16px;
+  padding-left: 20px;
+  line-height: 24px;
+}
+
+.svc-dragged-element-shortcut--selected {
+  border: 2px solid $secondary;
+}
+
 .svc-question__content--drag-over-inside,
 .svc-hovered > .svc-question__content--drag-over-inside {
   border: 2px solid $primary;

--- a/packages/survey-creator-core/src/components/question.ts
+++ b/packages/survey-creator-core/src/components/question.ts
@@ -168,7 +168,9 @@ export class QuestionAdornerViewModel extends ActionContainerViewModel<SurveyMod
   }
 
   startDragSurveyElement(event: PointerEvent) {
-    this.dragDropHelper.startDrag(event, <any>this.surveyElement);
+    const element = <any>this.surveyElement;
+    const isElementSelected = this.creator.selectedElement === element;
+    this.dragDropHelper.startDragSurveyElement(event, element, isElementSelected);
     return true;
   }
 


### PR DESCRIPTION
see https://github.com/surveyjs/survey-creator/issues/2172