### PR TITLE
Is there a way to hide specific fields in the translation tab and/or disable the 'show all pages' dropdown? #1863

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
@@ -1,4 +1,4 @@
-import { SurveyModel, PopupModel, ListModel, Action, IAction, ComputedUpdater } from "survey-core";
+import { SurveyModel, PopupModel, ListModel, Action, IAction, ComputedUpdater, JsonObjectProperty, Base } from "survey-core";
 import { CreatorBase, ICreatorPlugin } from "../../creator-base";
 import { editorLocalization, getLocString } from "../../editorLocalization";
 import { SideBarTabModel } from "../side-bar/side-bar-tab-model";
@@ -25,6 +25,11 @@ export class TabTranslationPlugin implements ICreatorPlugin {
   }
   public activate(): void {
     this.model = new Translation(this.creator.survey, this.creator);
+    this.model.translationStringVisibilityCallback = (obj: Base, prop: JsonObjectProperty, visible: boolean) => {
+      const options = { obj: obj, prop: prop, visible: visible };
+      !this.creator.onTranslationStringVisibility.isEmpty && this.creator.onTranslationStringVisibility.fire(self, options);
+      return options.visible;
+    };
     this.sideBarTab.model = this.model.settingsSurvey;
     this.sideBarTab.componentName = "survey-widget";
     this.creator.sideBar.activeTab = this.sideBarTab.id;
@@ -61,6 +66,8 @@ export class TabTranslationPlugin implements ICreatorPlugin {
         this.mergeLocaleWithDefaultAction.tooltip = this.model.mergeLocaleWithDefaultText;
       }
     });
+
+    this.model.reset();
   }
   public update(): void {
     if (!this.model) return;

--- a/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
@@ -1,4 +1,4 @@
-import { SurveyModel, PopupModel, ListModel, Action, IAction, ComputedUpdater, JsonObjectProperty, Base } from "survey-core";
+import { SurveyModel, PopupModel, ListModel, Action, IAction, Base } from "survey-core";
 import { CreatorBase, ICreatorPlugin } from "../../creator-base";
 import { editorLocalization, getLocString } from "../../editorLocalization";
 import { SideBarTabModel } from "../side-bar/side-bar-tab-model";
@@ -25,8 +25,8 @@ export class TabTranslationPlugin implements ICreatorPlugin {
   }
   public activate(): void {
     this.model = new Translation(this.creator.survey, this.creator);
-    this.model.translationStringVisibilityCallback = (obj: Base, prop: JsonObjectProperty, visible: boolean) => {
-      const options = { obj: obj, prop: prop, visible: visible };
+    this.model.translationStringVisibilityCallback = (obj: Base, propertyName: string, visible: boolean) => {
+      const options = { obj: obj, propertyName: propertyName, visible: visible };
       !this.creator.onTranslationStringVisibility.isEmpty && this.creator.onTranslationStringVisibility.fire(self, options);
       return options.visible;
     };

--- a/packages/survey-creator-core/src/components/tabs/translation.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation.ts
@@ -480,7 +480,7 @@ export class Translation extends Base implements ITranslationLocales {
     value: string,
     context: any
   ) => void;
-  public translationStringVisibilityCallback: (obj: Base, prop: JsonObjectProperty, visible: boolean) => boolean;
+  public translationStringVisibilityCallback: (obj: Base, propertyName: string, visible: boolean) => boolean;
   private surveyValue: SurveyModel;
   private settingsSurveyValue: SurveyModel;
   private onBaseObjCreatingCallback: (obj: Base) => void;
@@ -863,10 +863,8 @@ export class Translation extends Base implements ITranslationLocales {
   }
   private getMergeLocaleWithDefaultText(): string {
     if (!this.canMergeLocaleWithDefault) return "";
-    var locText = this.getLocaleName(this.defaultLocale);
-    return editorLocalization
-      .getString("ed.translationMergeLocaleWithDefault")
-      ["format"](locText);
+    const locText = this.getLocaleName(this.defaultLocale);
+    return editorLocalization.getString("ed.translationMergeLocaleWithDefault")["format"](locText);
   }
 
   public get survey(): SurveyModel {
@@ -891,7 +889,7 @@ export class Translation extends Base implements ITranslationLocales {
 
   public canShowProperty(obj: Base, prop: JsonObjectProperty, isEmpty: boolean): boolean {
     const result = !isEmpty || SurveyHelper.isPropertyVisible(obj, prop, this.options);
-    return this.translationStringVisibilityCallback ? this.translationStringVisibilityCallback(obj, prop, result) : result;
+    return this.translationStringVisibilityCallback ? this.translationStringVisibilityCallback(obj, prop.name, result) : result;
   }
   public get defaultLocale(): string {
     return surveyLocalization.defaultLocale;

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -662,6 +662,9 @@ export class CreatorBase<T extends SurveyModel = SurveyModel>
     (sender: CreatorBase<T>, options: any) => any,
     any
   > = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
+
+  public onTranslationStringVisibility: Survey.Event<(sender: CreatorBase<T>, options: any) => any, any> = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
+
   /**
    * This callback is used internally for providing survey JSON text.
    */
@@ -1261,9 +1264,9 @@ export class CreatorBase<T extends SurveyModel = SurveyModel>
     parentObj: Survey.Base,
     parentProperty: Survey.JsonObjectProperty
   ): boolean {
-    var proposedValue = this.readOnly || readOnly;
+    const proposedValue = this.readOnly || readOnly;
     if (this.onGetPropertyReadOnly.isEmpty) return proposedValue;
-    var options = {
+    const options = {
       obj: obj,
       property: property,
       readOnly: proposedValue,
@@ -2495,7 +2498,7 @@ export class CreatorBase<T extends SurveyModel = SurveyModel>
     return {
       iconName: "icon-dots",
       action: () => {
-        popupModel.displayMode = this.isMobileView ? "overlay":"popup";
+        popupModel.displayMode = this.isMobileView ? "overlay" : "popup";
         popupModel.toggleVisibility();
       },
       popupModel: popupModel

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -662,7 +662,13 @@ export class CreatorBase<T extends SurveyModel = SurveyModel>
     (sender: CreatorBase<T>, options: any) => any,
     any
   > = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
-
+  /**
+   * Use this event to modify the list of the strings available in a translation tab.
+   * <br/> sender - the survey creator object that fires the event
+   * <br/> options.obj - the survey object which property translations are edited in the translation tab.
+   * <br/> options.propertyName - the name of the property.
+   * <br/> options.visible - a boolean value. You can change it to hide the property.
+   */
   public onTranslationStringVisibility: Survey.Event<(sender: CreatorBase<T>, options: any) => any, any> = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
 
   /**

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -1,4 +1,4 @@
-import { Serializer, SurveyModel, surveyLocalization, Base, QuestionDropdownModel, PanelModel, QuestionMatrixDropdownModel, QuestionTextModel, QuestionCommentModel, JsonObjectProperty, ExpressionItem } from "survey-core";
+import { Serializer, SurveyModel, surveyLocalization, Base, QuestionDropdownModel, PanelModel, QuestionMatrixDropdownModel, QuestionTextModel, QuestionCommentModel } from "survey-core";
 import { Translation, TranslationItem } from "../../src/components/tabs/translation";
 import { TabTranslationPlugin } from "../../src/components/tabs/translation-plugin";
 import { CreatorTester } from "../creator-tester";
@@ -581,9 +581,9 @@ test("translationStringVisibilityCallback", () => {
   expect(translation.root.groups[1].name).toEqual("page2");
   expect(translation.root.items[2].name).toEqual("title");
 
-  translation.translationStringVisibilityCallback = (obj: Base, prop: JsonObjectProperty, visible: boolean) => {
-    if (obj.getType() == "survey" && prop.name === "title") return false;
-    if (obj["name"] === "question1" && prop.name === "title") return false;
+  translation.translationStringVisibilityCallback = (obj: Base, propertyName: string, visible: boolean) => {
+    if (obj.getType() == "survey" && propertyName === "title") return false;
+    if (obj["name"] === "question1" && propertyName === "title") return false;
     return true;
   };
   translation.reset();
@@ -599,9 +599,9 @@ test("onTranslationStringVisibility", () => {
   const creator = new CreatorTester();
   creator.JSON = surveyJson;
   creator.onTranslationStringVisibility.add((sender, options) => {
-    if (options.obj.getType() == "survey" && options.prop.name === "title") {
+    if (options.obj.getType() == "survey" && options.propertyName === "title") {
       options.visible = false;
-    } else if (options.obj["name"] === "question1" && options.prop.name === "title") {
+    } else if (options.obj["name"] === "question1" && options.propertyName === "title") {
       options.visible = false;
     } else {
       options.visible = true;

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -1,30 +1,17 @@
-import {
-  Serializer,
-  SurveyModel,
-  surveyLocalization,
-  Base,
-  QuestionDropdownModel,
-  PanelModel,
-  QuestionMatrixDropdownModel,
-  QuestionTextModel,
-  QuestionCommentModel
-} from "survey-core";
-import {
-  Translation,
-  TranslationItem
-} from "../../src/components/tabs/translation";
+import { Serializer, SurveyModel, surveyLocalization, Base, QuestionDropdownModel, PanelModel, QuestionMatrixDropdownModel, QuestionTextModel, QuestionCommentModel, JsonObjectProperty, ExpressionItem } from "survey-core";
+import { Translation, TranslationItem } from "../../src/components/tabs/translation";
 import { TabTranslationPlugin } from "../../src/components/tabs/translation-plugin";
 import { CreatorTester } from "../creator-tester";
 
 test("Fire callback on base objects creation", () => {
-  var survey = new SurveyModel();
+  const survey = new SurveyModel();
   survey.addNewPage("p1");
-  var q = survey.pages[0].addNewQuestion("text", "q1");
+  const q = survey.pages[0].addNewQuestion("text", "q1");
   q.title = "some value";
-  var cretorHash = {};
-  var translation = new Translation(survey, null);
+  const cretorHash = {};
+  const translation = new Translation(survey, null);
   translation.makeObservable((obj: Base) => {
-    var type = obj.getType();
+    const type = obj.getType();
     if (!cretorHash[type]) {
       cretorHash[type] = 0;
     }
@@ -34,17 +21,17 @@ test("Fire callback on base objects creation", () => {
   expect(cretorHash["translationgroup"]).toEqual(3);
   expect(cretorHash["translationitem"]).toEqual(1);
   expect(cretorHash["translationitemstring"]).toBeFalsy();
-  var group = translation.root.groups[0];
+  let group = translation.root.groups[0];
   expect(group.items).toHaveLength(1);
   expect(group.items[0].name).toEqual("q1");
   group = group.groups[0];
   expect(group.items[0].name).toEqual("title");
-  var val = group.locItems[0].values("");
+  const val = group.locItems[0].values("");
   expect(cretorHash["translationitemstring"]).toEqual(1);
 });
 
 test("settingsSurvey layout", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -58,7 +45,7 @@ test("settingsSurvey layout", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   let panel = translation.settingsSurvey.getPanelByName("languages");
   expect(panel.elements).toHaveLength(2);
   let elements = panel.elements;
@@ -75,7 +62,7 @@ test("settingsSurvey layout", () => {
 });
 
 test("create available locales", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -96,7 +83,7 @@ test("create available locales", () => {
     ]
   });
   surveyLocalization.supportedLocales = ["fr", "de"];
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.settingsSurvey.getValue("selLocales")).toHaveLength(3);
   expect(translation.getSurveyLocales()[0]).toHaveLength(4);
   translation.addLocale("de");
@@ -104,7 +91,7 @@ test("create available locales", () => {
   surveyLocalization.supportedLocales = [];
 });
 test("create locales question", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -125,12 +112,12 @@ test("create locales question", () => {
     ]
   });
   surveyLocalization.supportedLocales = ["fr", "de"];
-  var translation = new Translation(survey);
-  var localesQuestion = <QuestionDropdownModel>(
+  const translation = new Translation(survey);
+  const localesQuestion = <QuestionDropdownModel>(
     translation.settingsSurvey.getQuestionByName("locales")
   );
   expect(localesQuestion.choices).toHaveLength(4);
-  var visChoices = localesQuestion.visibleChoices;
+  const visChoices = localesQuestion.visibleChoices;
   expect(visChoices).toHaveLength(3);
   expect(visChoices[0].value).toEqual("fr");
   expect(visChoices[1].value).toEqual("it");
@@ -143,7 +130,7 @@ test("create locales question", () => {
 });
 
 test("stringsSurvey - one question in survey", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -163,17 +150,17 @@ test("stringsSurvey - one question in survey", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.stringsSurvey.pages).toHaveLength(1);
-  var page = translation.stringsSurvey.pages[0];
+  const page = translation.stringsSurvey.pages[0];
   expect(page.elements).toHaveLength(1);
-  var pagePanel = <PanelModel>page.elements[0];
+  const pagePanel = <PanelModel>page.elements[0];
   expect(pagePanel.name).toEqual("page1");
   expect(pagePanel.elements).toHaveLength(1);
   expect(pagePanel.elements[0].name).toEqual("question1");
-  var question1 = <PanelModel>pagePanel.elements[0];
+  const question1 = <PanelModel>pagePanel.elements[0];
   expect(question1.elements).toHaveLength(2);
-  var question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
+  const question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
   expect(question1Props.name).toEqual("question1_props");
   expect(question1Props.titleLocation).toEqual("hidden");
   expect(question1Props.columns).toHaveLength(4);
@@ -182,8 +169,8 @@ test("stringsSurvey - one question in survey", () => {
   expect(question1Props.rows).toHaveLength(1);
   expect(question1Props.rows[0].value).toEqual("title");
   expect(question1Props.rows[0].text).toEqual("Title");
-  var choicesPanel = <PanelModel>question1.elements[1];
-  var choicesProps = <QuestionMatrixDropdownModel>choicesPanel.elements[0];
+  const choicesPanel = <PanelModel>question1.elements[1];
+  const choicesProps = <QuestionMatrixDropdownModel>choicesPanel.elements[0];
   expect(choicesProps.name).toEqual("question1_choices");
   expect(choicesProps.columns).toHaveLength(4);
   expect(choicesProps.columns[0].name).toEqual("default");
@@ -203,21 +190,16 @@ test("stringsSurvey - one question in survey", () => {
       es: "quéstion 1"
     }
   });
-  expect(question1Props.visibleRows[0].cells[1].question.getType()).toEqual(
-    "comment"
-  );
-  expect(question1Props.visibleRows[0].cells[1].question.value).toEqual(
-    "quéstion 1"
-  );
-  var translationItem: TranslationItem =
-    question1Props.rows[0]["translationData"];
+  expect(question1Props.visibleRows[0].cells[1].question.getType()).toEqual("comment");
+  expect(question1Props.visibleRows[0].cells[1].question.value).toEqual("quéstion 1");
+  const translationItem: TranslationItem = question1Props.rows[0]["translationData"];
   expect(translationItem.getLocText("fr")).toEqual("quéstion 1");
   question1Props.visibleRows[0].cells[1].question.value = "changed fr";
   expect(translationItem.getLocText("fr")).toEqual("changed fr");
 });
 
 test("Add/remove columns on adding/removing locales", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -239,8 +221,8 @@ test("Add/remove columns on adding/removing locales", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
-  var matrix = <QuestionMatrixDropdownModel>(
+  const translation = new Translation(survey);
+  const matrix = <QuestionMatrixDropdownModel>(
     translation.stringsSurvey.getAllQuestions()[0]
   );
   expect(matrix.columns).toHaveLength(1);
@@ -248,7 +230,7 @@ test("Add/remove columns on adding/removing locales", () => {
   expect(matrix.columns).toHaveLength(2);
 });
 test("stringsSurvey and filterPage", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -272,13 +254,13 @@ test("stringsSurvey and filterPage", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.stringsSurvey.getAllQuestions()).toHaveLength(2);
   translation.filteredPage = survey.pages[0];
   expect(translation.stringsSurvey.getAllQuestions()).toHaveLength(1);
 });
 test("stringsSurvey and filterPage + one page", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -292,13 +274,13 @@ test("stringsSurvey and filterPage + one page", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.stringsSurvey.getAllQuestions()).toHaveLength(1);
   translation.filteredPage = survey.pages[0];
   expect(translation.stringsSurvey.getAllQuestions()).toHaveLength(1);
 });
 test("Translation show All strings and property visibility", () => {
-  var creator = new CreatorTester();
+  const creator = new CreatorTester();
   creator.JSON = {
     completedHtml: "Test",
     pages: [
@@ -311,15 +293,15 @@ test("Translation show All strings and property visibility", () => {
   creator.onShowingProperty.add((sender, options) => {
     options.canShow = options.property.name == "title";
   });
-  var tabTranslation = new TabTranslationPlugin(creator);
+  const tabTranslation = new TabTranslationPlugin(creator);
   tabTranslation.activate();
-  var translation = tabTranslation.model;
+  const translation = tabTranslation.model;
   expect(translation.root.locItems).toHaveLength(1);
   translation.showAllStrings = true;
   expect(translation.root.locItems).toHaveLength(2);
 });
 test("Translation make translation observable", () => {
-  var creator = new CreatorTester();
+  const creator = new CreatorTester();
   creator.JSON = {
     completedHtml: "Test",
     pages: [
@@ -329,9 +311,9 @@ test("Translation make translation observable", () => {
       }
     ]
   };
-  var tabTranslation = new TabTranslationPlugin(creator);
+  const tabTranslation = new TabTranslationPlugin(creator);
   tabTranslation.activate();
-  var translation = tabTranslation.model;
+  const translation = tabTranslation.model;
   translation.makeObservable((obj: Base) => {
     obj["tag"] = "Hello!";
   });
@@ -363,7 +345,7 @@ test("Translation update filterPageActiontitle after activated", () => {
 });
 
 test("StringsHeaderSurvey layout", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -385,9 +367,9 @@ test("StringsHeaderSurvey layout", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
-  var stringsMatrix = <QuestionMatrixDropdownModel>(translation.stringsSurvey.getAllQuestions()[0]);
-  var headerMatrix = <QuestionMatrixDropdownModel>(translation.stringsHeaderSurvey.getAllQuestions()[0]);
+  const translation = new Translation(survey);
+  const stringsMatrix = <QuestionMatrixDropdownModel>(translation.stringsSurvey.getAllQuestions()[0]);
+  const headerMatrix = <QuestionMatrixDropdownModel>(translation.stringsHeaderSurvey.getAllQuestions()[0]);
   expect(stringsMatrix.rowTitleWidth).toEqual("300px");
   expect(stringsMatrix.columns).toHaveLength(1);
   expect(stringsMatrix.columns[0].width).toEqual("calc((100% - 300px)/1)");
@@ -419,7 +401,7 @@ test("Actions mode small", () => {
 });
 
 test("Make invisible locales in language selector, that has been already choosen", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     pages: [
       {
         name: "page1",
@@ -442,7 +424,7 @@ test("Make invisible locales in language selector, that has been already choosen
     ]
   });
   surveyLocalization.supportedLocales = ["en", "fr", "de", "se"];
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.chooseLanguageActions).toHaveLength(4);
   expect(translation.chooseLanguageActions[0].id).toEqual("en");
   expect(translation.chooseLanguageActions[1].id).toEqual("fr");
@@ -453,7 +435,7 @@ test("Make invisible locales in language selector, that has been already choosen
   surveyLocalization.supportedLocales = [];
 });
 test("stringsSurvey - text question dataList property, default", () => {
-  var survey = new SurveyModel({
+  const survey = new SurveyModel({
     elements: [
       {
         type: "text",
@@ -464,16 +446,16 @@ test("stringsSurvey - text question dataList property, default", () => {
       }
     ]
   });
-  var translation = new Translation(survey);
+  const translation = new Translation(survey);
   expect(translation.stringsSurvey.pages).toHaveLength(1);
-  var page = translation.stringsSurvey.pages[0];
+  const page = translation.stringsSurvey.pages[0];
   expect(page.elements).toHaveLength(1);
-  var pagePanel = <PanelModel>page.elements[0];
+  const pagePanel = <PanelModel>page.elements[0];
   expect(pagePanel.elements).toHaveLength(1);
   expect(pagePanel.elements[0].name).toEqual("question1");
-  var question1 = <PanelModel>pagePanel.elements[0];
+  const question1 = <PanelModel>pagePanel.elements[0];
   expect(question1.elements).toHaveLength(1);
-  var question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
+  const question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
   expect(question1Props.name).toEqual("question1_props");
   expect(question1Props.columns).toHaveLength(1);
   expect(question1Props.columns[0].name).toEqual("default");
@@ -506,7 +488,7 @@ test("stringsSurvey - text question dataList property, several locales", () => {
   const pagePanel = <PanelModel>page.elements[0];
   const question1 = <PanelModel>pagePanel.elements[0];
   expect(question1.elements).toHaveLength(1);
-  var question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
+  const question1Props = <QuestionMatrixDropdownModel>question1.elements[0];
   expect(question1Props.columns).toHaveLength(2);
   expect(question1Props.columns[0].name).toEqual("default");
   expect(question1Props.columns[1].name).toEqual("de");
@@ -558,4 +540,81 @@ test("Respect property maxLength attrigute in stringsSurvey comment questions", 
   Serializer.findProperty("question", "title").maxLength = -1;
   Serializer.findProperty("page", "title").maxLength = -1;
   Serializer.findProperty("survey", "title").maxLength = -1;
+});
+
+const surveyJson = {
+  "title": "Survey title",
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "text",
+          "name": "question1"
+        }
+      ],
+      "title": "Page1 title"
+    },
+    {
+      "name": "page2",
+      "elements": [
+        {
+          "type": "text",
+          "name": "question2"
+        }
+      ]
+    }
+  ]
+};
+test("translationStringVisibilityCallback", () => {
+  const survey = new SurveyModel(surveyJson);
+
+  const translation = new Translation(survey, null);
+  expect(translation.root.items).toHaveLength(3);
+  expect(translation.root.groups).toHaveLength(2);
+  expect(translation.root.groups[0].name).toEqual("page1");
+  expect(translation.root.groups[0].items).toHaveLength(2);
+  expect(translation.root.groups[0].groups).toHaveLength(1);
+  expect(translation.root.groups[0].groups[0].name).toEqual("question1");
+  expect(translation.root.groups[0].groups[0].items[0].name).toEqual("title");
+  expect(translation.root.groups[0].items[1].name).toEqual("title");
+  expect(translation.root.groups[1].name).toEqual("page2");
+  expect(translation.root.items[2].name).toEqual("title");
+
+  translation.translationStringVisibilityCallback = (obj: Base, prop: JsonObjectProperty, visible: boolean) => {
+    if (obj.getType() == "survey" && prop.name === "title") return false;
+    if (obj["name"] === "question1" && prop.name === "title") return false;
+    return true;
+  };
+  translation.reset();
+  expect(translation.root.items).toHaveLength(2);
+  expect(translation.root.groups).toHaveLength(2);
+  expect(translation.root.groups[0].name).toEqual("page1");
+  expect(translation.root.groups[0].items).toHaveLength(1);
+  expect(translation.root.groups[0].items[0].name).toEqual("title");
+  expect(translation.root.groups[1].name).toEqual("page2");
+});
+
+test("onTranslationStringVisibility", () => {
+  const creator = new CreatorTester();
+  creator.JSON = surveyJson;
+  creator.onTranslationStringVisibility.add((sender, options) => {
+    if (options.obj.getType() == "survey" && options.prop.name === "title") {
+      options.visible = false;
+    } else if (options.obj["name"] === "question1" && options.prop.name === "title") {
+      options.visible = false;
+    } else {
+      options.visible = true;
+    }
+  });
+  const tabTranslation = new TabTranslationPlugin(creator);
+  tabTranslation.activate();
+  const translation = tabTranslation.model;
+
+  expect(translation.root.items).toHaveLength(2);
+  expect(translation.root.groups).toHaveLength(2);
+  expect(translation.root.groups[0].name).toEqual("page1");
+  expect(translation.root.groups[0].items).toHaveLength(1);
+  expect(translation.root.groups[0].items[0].name).toEqual("title");
+  expect(translation.root.groups[1].name).toEqual("page2");
 });

--- a/packages/survey-creator/src/creator-base.ts
+++ b/packages/survey-creator/src/creator-base.ts
@@ -17,8 +17,7 @@ export interface ICreatorOptions {
  * Base class for Survey Creator.
  */
 export class CreatorBase<T extends { [index: string]: any }>
-implements ISurveyCreatorOptions
-{
+implements ISurveyCreatorOptions {
   private showDesignerTabValue = ko.observable<boolean>(false);
   private showJSONEditorTabValue = ko.observable<boolean>(false);
   private showTestSurveyTabValue = ko.observable<boolean>(false);
@@ -248,6 +247,9 @@ implements ISurveyCreatorOptions
     (sender: CreatorBase<T>, options: any) => any,
     any
   > = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
+
+  public onTranslationStringVisibility: Survey.Event<(sender: CreatorBase<T>, options: any) => any, any> = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
+
   /**
    * This callback is used internally for providing survey JSON text.
    */
@@ -411,7 +413,7 @@ implements ISurveyCreatorOptions
 
   koReadOnly = ko.observable(false);
 
-  protected onSetReadOnly(newVal: boolean) {}
+  protected onSetReadOnly(newVal: boolean) { }
 
   /**
    * A boolean property, false by default. Set it to true to deny editing.
@@ -468,7 +470,7 @@ implements ISurveyCreatorOptions
     return true;
   }
 
-  protected onViewTypeChanged(newType: string) {}
+  protected onViewTypeChanged(newType: string) { }
 
   protected canSwitchViewType(newType: string) {
     return true;
@@ -761,7 +763,7 @@ implements ISurveyCreatorOptions
     return survey;
   }
 
-  public setModified(options: any = null) {}
+  public setModified(options: any = null) { }
 
   protected convertCurrentObject(obj: Survey.Question, className: string) {
     this.startTransaction("Convert question to: " + className);
@@ -775,7 +777,7 @@ implements ISurveyCreatorOptions
     });
   }
 
-  protected initSurveyWithJSON(json: any, clearState: boolean) {}
+  protected initSurveyWithJSON(json: any, clearState: boolean) { }
 
   /**
    * The Survey JSON. Use it to get Survey JSON or change it.
@@ -973,7 +975,7 @@ implements ISurveyCreatorOptions
     }
   }
 
-  public selectElement(element: any) {}
+  public selectElement(element: any) { }
 
   protected deletePanelOrQuestion(obj: Survey.Base, objType: ObjType): void {
     var parent = obj["parent"];
@@ -1060,7 +1062,7 @@ implements ISurveyCreatorOptions
     }
     return true;
   }
-  protected doPropertyGridChanged() {}
+  protected doPropertyGridChanged() { }
 
   //implements ISurveyCreatorOptions
   get alwaySaveTextInPropertyEditors(): boolean {
@@ -1219,5 +1221,5 @@ implements ISurveyCreatorOptions
   protected startTransaction(name: string) {
 
   }
-  protected stopTransation() {}
+  protected stopTransation() { }
 }

--- a/packages/survey-creator/src/creator-base.ts
+++ b/packages/survey-creator/src/creator-base.ts
@@ -247,7 +247,13 @@ implements ISurveyCreatorOptions {
     (sender: CreatorBase<T>, options: any) => any,
     any
   > = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
-
+  /**
+   * Use this event to modify the list of the strings available in a translation tab.
+   * <br/> sender - the survey creator object that fires the event
+   * <br/> options.obj - the survey object which property translations are edited in the translation tab.
+   * <br/> options.propertyName - the name of the property.
+   * <br/> options.visible - a boolean value. You can change it to hide the property.
+   */
   public onTranslationStringVisibility: Survey.Event<(sender: CreatorBase<T>, options: any) => any, any> = new Survey.Event<(sender: CreatorBase<T>, options: any) => any, any>();
 
   /**

--- a/packages/survey-creator/src/tabs/translation.ts
+++ b/packages/survey-creator/src/tabs/translation.ts
@@ -442,7 +442,7 @@ export class Translation implements ITranslationLocales {
     value: string,
     context: any
   ) => void;
-  public translationStringVisibilityCallback: (obj: Survey.Base, prop: Survey.JsonObjectProperty, visible: boolean) => boolean;
+  public translationStringVisibilityCallback: (obj: Survey.Base, propertyName: string, visible: boolean) => boolean;
   private rootValue: TranslationGroup;
   private surveyValue: Survey.Survey;
 
@@ -637,7 +637,7 @@ export class Translation implements ITranslationLocales {
   }
   public canShowProperty(obj: Survey.Base, prop: Survey.JsonObjectProperty, isEmpty: boolean): boolean {
     const result = !isEmpty || !this.onCanShowProperty || this.onCanShowProperty(obj, prop);
-    return this.translationStringVisibilityCallback ? this.translationStringVisibilityCallback(obj, prop, result) : result;
+    return this.translationStringVisibilityCallback ? this.translationStringVisibilityCallback(obj, prop.name, result) : result;
   }
   public get showAllStrings(): boolean {
     return this.koShowAllStrings();
@@ -867,8 +867,8 @@ export class TranslationViewModel {
         return SurveyHelper.isPropertyVisible(obj, prop, creator);
       }
     );
-    this.model.translationStringVisibilityCallback = (obj: Survey.Base, prop: Survey.JsonObjectProperty, visible: boolean) => {
-      const options = { obj: obj, prop: prop, visible: visible };
+    this.model.translationStringVisibilityCallback = (obj: Survey.Base, propertyName: string, visible: boolean) => {
+      const options = { obj: obj, propertyName: propertyName, visible: visible };
       !creator.onTranslationStringVisibility.isEmpty && creator.onTranslationStringVisibility.fire(self, options);
       return options.visible;
     };

--- a/packages/survey-creator/tests/translationtest.ts
+++ b/packages/survey-creator/tests/translationtest.ts
@@ -1,10 +1,6 @@
 import * as ko from "knockout";
 import * as Survey from "survey-knockout";
-import {
-  TranslationGroup,
-  TranslationItem,
-  Translation,
-} from "../src/tabs/translation";
+import { TranslationGroup, TranslationItem, Translation, TranslationViewModel } from "../src/tabs/translation";
 import { SurveyCreator } from "../src/editor";
 import { unparse, parse } from "papaparse";
 import { settings } from "../src/settings";
@@ -793,10 +789,9 @@ QUnit.test("Two new functions: expandAll(), collapseAll()", function (assert) {
     "The q1 group  is collapse as well"
   );
 });
-QUnit.test(
-  "Translation show All strings and property visibility",
+QUnit.test("Translation show All strings and property visibility",
   function (assert) {
-    var creator = new SurveyCreator();
+    const creator = new SurveyCreator();
     creator.JSON = {
       completedHtml: "Test",
       pages: [
@@ -809,18 +804,11 @@ QUnit.test(
     creator.onShowingProperty.add((sender, options) => {
       options.canShow = options.property.name == "title";
     });
-    var translation = new Translation(creator.survey);
-    assert.equal(
-      translation.root.locItems.length,
-      1,
-      "There is one item to translate - completedHtml"
-    );
+    let translation = new Translation(creator.survey);
+    assert.equal(translation.root.locItems.length, 1, "There is one item to translate - completedHtml");
     translation.showAllStrings = true;
-    assert.ok(
-      translation.root.locItems.length > 5,
-      "Show a lot of items - completedHtml"
-    );
-    var translation = new Translation(
+    assert.ok(translation.root.locItems.length > 5, "Show a lot of items - completedHtml");
+    translation = new Translation(
       creator.survey,
       true,
       ko.computed(() => creator.readOnly),
@@ -828,13 +816,88 @@ QUnit.test(
         return SurveyHelper.isPropertyVisible(obj, prop, creator);
       }
     );
-    assert.equal(
-      translation.root.locItems.length,
-      2,
-      "There are two items to translate - completedHtml + title"
-    );
+    assert.equal(translation.root.locItems.length, 2, "There are two items to translate - completedHtml + title");
   }
 );
+
+const surveyJson = {
+  "title": "Survey title",
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "text",
+          "name": "question1"
+        }
+      ],
+      "title": "Page1 title"
+    },
+    {
+      "name": "page2",
+      "elements": [
+        {
+          "type": "text",
+          "name": "question2"
+        }
+      ]
+    }
+  ]
+};
+
+QUnit.test("translationStringVisibilityCallback", (assert) => {
+  const creator = new SurveyCreator();
+  creator.JSON = surveyJson;
+  const translation = new Translation(creator.survey, null, undefined, (obj: Survey.Base, prop: Survey.JsonObjectProperty): boolean => {
+    return SurveyHelper.isPropertyVisible(obj, prop, creator);
+  });
+  assert.equal(translation.root.items.length, 3);
+  assert.equal(translation.root.items[0].name, "title");
+  assert.equal(translation.root.groups.length, 2);
+  assert.equal(translation.root.groups[0].name, "page1");
+  assert.equal(translation.root.groups[0].items.length, 2);
+  assert.equal(translation.root.groups[0].items[0].name, "title");
+  assert.equal(translation.root.groups[0].groups.length, 1);
+  assert.equal(translation.root.groups[0].groups[0].name, "question1");
+  assert.equal(translation.root.groups[0].groups[0].items[0].name, "title");
+  assert.equal(translation.root.groups[1].name, "page2");
+
+  translation.translationStringVisibilityCallback = (obj: Survey.Base, prop: Survey.JsonObjectProperty, visible: boolean) => {
+    if (obj.getType() == "survey" && prop.name === "title") return false;
+    if (obj["name"] === "question1" && prop.name === "title") return false;
+    return true;
+  };
+  translation.reset();
+  assert.equal(translation.root.items.length, 2);
+  assert.equal(translation.root.groups.length, 2);
+  assert.equal(translation.root.groups[0].name, "page1");
+  assert.equal(translation.root.groups[0].items.length, 1);
+  assert.equal(translation.root.groups[0].items[0].name, "title");
+  assert.equal(translation.root.groups[1].name, "page2");
+});
+
+QUnit.test("onTranslationStringVisibility", (assert) => {
+  const creator = new SurveyCreator();
+  creator.JSON = surveyJson;
+  creator.onTranslationStringVisibility.add((sender, options) => {
+    if (options.obj.getType() == "survey" && options.prop.name === "title") {
+      options.visible = false;
+    } else if (options.obj["name"] === "question1" && options.prop.name === "title") {
+      options.visible = false;
+    } else {
+      options.visible = true;
+    }
+  });
+  const tabTranslation = new TranslationViewModel(creator);
+  const translation = tabTranslation.model;
+
+  assert.equal(translation.root.items.length, 2);
+  assert.equal(translation.root.groups.length, 2);
+  assert.equal(translation.root.groups[0].name, "page1");
+  assert.equal(translation.root.groups[0].items.length, 1);
+  assert.equal(translation.root.groups[0].items[0].name, "title");
+  assert.equal(translation.root.groups[1].name, "page2");
+});
 
 /* TODO wait for v1.8.29
 QUnit.test("check LocalizableStrings/dataList property", function (assert) {

--- a/packages/survey-creator/tests/translationtest.ts
+++ b/packages/survey-creator/tests/translationtest.ts
@@ -862,9 +862,9 @@ QUnit.test("translationStringVisibilityCallback", (assert) => {
   assert.equal(translation.root.groups[0].groups[0].items[0].name, "title");
   assert.equal(translation.root.groups[1].name, "page2");
 
-  translation.translationStringVisibilityCallback = (obj: Survey.Base, prop: Survey.JsonObjectProperty, visible: boolean) => {
-    if (obj.getType() == "survey" && prop.name === "title") return false;
-    if (obj["name"] === "question1" && prop.name === "title") return false;
+  translation.translationStringVisibilityCallback = (obj: Survey.Base, propertyName: string, visible: boolean) => {
+    if (obj.getType() == "survey" && propertyName === "title") return false;
+    if (obj["name"] === "question1" && propertyName === "title") return false;
     return true;
   };
   translation.reset();
@@ -880,9 +880,9 @@ QUnit.test("onTranslationStringVisibility", (assert) => {
   const creator = new SurveyCreator();
   creator.JSON = surveyJson;
   creator.onTranslationStringVisibility.add((sender, options) => {
-    if (options.obj.getType() == "survey" && options.prop.name === "title") {
+    if (options.obj.getType() == "survey" && options.propertyName === "title") {
       options.visible = false;
-    } else if (options.obj["name"] === "question1" && options.prop.name === "title") {
+    } else if (options.obj["name"] === "question1" && options.propertyName === "title") {
       options.visible = false;
     } else {
       options.visible = true;


### PR DESCRIPTION
https://github.com/surveyjs/survey-creator/issues/1863