### PR TITLE
resolve #2268 - keep Expand Property Grid action in the end of toolbar

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -90,6 +90,22 @@ export class TabbedMenuContainer extends AdaptiveActionContainer<TabbedMenuItem>
   }
 }
 
+export class ToolbarActionContainer extends ActionContainer {
+  constructor(private creator: CreatorBase) {
+    super();
+  }
+  protected getRenderedActions(): Array<Action> {
+    let actions = this.actions;
+    const expandAction = this.creator.sideBar.getExpandAction();
+    var index = actions.indexOf(expandAction);
+    if (index !== -1) {
+      actions.splice(index, 1);
+      actions.push(expandAction);
+    }
+    return actions;
+  }
+}
+
 export type toolBoxLocationType = "left" | "right" | "insideSideBar" | "hidden";
 
 /**
@@ -864,7 +880,7 @@ export class CreatorBase<T extends SurveyModel = SurveyModel>
       this.options = !!options2 ? options2 : {};
       SurveyHelper.warnText("Creator constructor has one parameter, as creator options, in V2.");
     }
-    this.toolbarValue = new ActionContainer();
+    this.toolbarValue = new ToolbarActionContainer(this);
     this.pagesControllerValue = new PagesController(this);
     this.selectionHistoryControllerValue = new SelectionHistory(this);
     this.sideBar = new SideBarModel(this);

--- a/packages/survey-creator-core/tests/creator-base.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base.tests.ts
@@ -13,7 +13,8 @@ import {
   settings as surveySettings,
   QuestionPanelDynamicModel,
   CustomWidgetCollection,
-  QuestionMatrixModel
+  QuestionMatrixModel,
+  Action
 } from "survey-core";
 import { PageViewModel } from "../src/components/page";
 import { QuestionAdornerViewModel } from "../src/components/question";
@@ -1336,6 +1337,34 @@ test("Show/hide property grid by collapse/expand actions", (): any => {
 
   settings.propertyGrid.allowCollapse = prevValue;
 });
+
+test("Check property grid expand action is always last", (): any => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    pages: [
+      {
+        elements: [
+          {
+            type: "text",
+            name: "question1"
+          }
+        ]
+      }
+    ]
+  };
+
+  const index = creator.toolbar.renderedActions.length - 1;
+  expect(creator.toolbar.renderedActions[index].id).toEqual("svd-grid-expand");
+  creator.toolbarItems.push(new Action({
+    id: "test-action",
+    visible: true,
+    title: "Test action",
+    action: function () {}
+  }));
+  expect(creator.toolbar.renderedActions[index].id).toEqual("test-action");
+  expect(creator.toolbar.renderedActions[index + 1].id).toEqual("svd-grid-expand");
+});
+
 test("Show survey in property grid on deleting last page", (): any => {
   const creator = new CreatorTester();
   creator.JSON = {


### PR DESCRIPTION
resolve #2268