### PR TITLE
Work for #2723: fix translation tab in safari

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/translation.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation.ts
@@ -744,12 +744,14 @@ export class Translation extends Base implements ITranslationLocales {
   private addLocaleColumns(matrix: QuestionMatrixDropdownModel) {
     var locs = this.getSelectedLocales();
     matrix.rowTitleWidth = "300px";
-    const width = "calc((100% - " + matrix.rowTitleWidth + ")/" + (locs.length + 1) + ")";
-    const defaultColumn = matrix.addColumn("default", this.getLocaleName(""));
-    defaultColumn.width = width;
+    // const width = "calc((100% - " + matrix.rowTitleWidth + ")/" + (locs.length + 1) + ")";
+    // const defaultColumn =
+    matrix.addColumn("default", this.getLocaleName(""));
+    // defaultColumn.width = width;
     for (var i = 0; i < locs.length; i++) {
-      let column = matrix.addColumn(locs[i], this.getLocaleName(locs[i]));
-      column.width = width;
+      // let column =
+      matrix.addColumn(locs[i], this.getLocaleName(locs[i]));
+      // column.width = width;
     }
   }
   private getStringsSurveyQuestionName(

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -434,20 +434,20 @@ test("StringsHeaderSurvey layout", () => {
   const headerMatrix = <QuestionMatrixDropdownModel>(translation.stringsHeaderSurvey.getAllQuestions()[0]);
   expect(stringsMatrix.rowTitleWidth).toEqual("300px");
   expect(stringsMatrix.columns).toHaveLength(1);
-  expect(stringsMatrix.columns[0].width).toEqual("calc((100% - 300px)/1)");
+  // expect(stringsMatrix.columns[0].width).toEqual("calc((100% - 300px)/1)");
 
   expect(headerMatrix.rowTitleWidth).toEqual("300px");
   expect(headerMatrix.columns).toHaveLength(1);
-  expect(headerMatrix.columns[0].width).toEqual("calc((100% - 300px)/1)");
+  // expect(headerMatrix.columns[0].width).toEqual("calc((100% - 300px)/1)");
 
   translation.addLocale("de");
   expect(stringsMatrix.rowTitleWidth).toEqual("300px");
   expect(stringsMatrix.columns).toHaveLength(2);
-  expect(stringsMatrix.columns[0].width).toEqual("calc((100% - 300px)/2)");
+  // expect(stringsMatrix.columns[0].width).toEqual("calc((100% - 300px)/2)");
 
   expect(headerMatrix.rowTitleWidth).toEqual("300px");
   expect(headerMatrix.columns).toHaveLength(2);
-  expect(headerMatrix.columns[0].width).toEqual("calc((100% - 300px)/2)");
+  // expect(headerMatrix.columns[0].width).toEqual("calc((100% - 300px)/2)");
 });
 
 test("Actions mode small", () => {


### PR DESCRIPTION
Remove column width calculation in translation tab(not needed in case of fixed layout). It breaks translation in safari