### PR TITLE
V2: Support onDragDropAllow event

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
     // "javascript.format.insertSpaceAfterKeywordsInControlFlowStatements": false,
     "editor.tabSize": 2,
     "editor.formatOnSave": true,
-    "eslint.format.enable": true
+    "eslint.format.enable": true,
+    "editor.accessibilitySupport": "off"
 }

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -748,6 +748,21 @@ export class CreatorBase extends Base
    */
   public onTranslationLocaleInitiallySelected: Survey.Event<(sender: CreatorBase, options: any) => any, any> = new Survey.Event<(sender: CreatorBase, options: any) => any, any>();
   /**
+   * Use this event to control drag&drop operations.
+   * <br/> sender the survey creator object that fires the event.
+   * <br/> options.survey the editing survey object.
+   * <br/> options.allow set it to false to disable dragging.
+   * <br/> options.target a target element that is dragging.
+   * <br/> options.source a source element. It can be null, if it is a new element, dragging from toolbox.
+   * <br/> options.parent a page or panel where target element is dragging.
+   * <br/> options.insertBefore an element before the target element is dragging. It can be null if parent container (page or panel) is empty or dragging an element under the last element of the container.
+   * <br/> options.insertAfter an element after the target element is dragging. It can be null if parent container (page or panel) is empty or dragging element to the top of the parent container.
+   */
+  public onDragDropAllow: Survey.Event<
+    (sender: CreatorBase, options: any) => any,
+    any
+  > = new Survey.Event<(sender: CreatorBase, options: any) => any, any>();
+  /**
    * This callback is used internally for providing survey JSON text.
    */
   public getSurveyJSONTextCallback: () => { text: string, isModified: boolean };
@@ -1471,6 +1486,10 @@ export class CreatorBase extends Base
       this.doOnPageAdded(options.page);
     });
     survey.onGetMatrixRowActions.add((_, opt) => { updateMatrixRemoveAction(opt.question, opt.actions, opt.row); });
+    survey.onDragDropAllow.add(function (sender, options) {
+      options.survey = sender;
+      this.onDragDropAllow.fire(self, options);
+    });
     this.setSurvey(survey);
     const currentPlugin = this.getPlugin(this.activeTab);
     if (!!currentPlugin && !!currentPlugin.update) {

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -1486,10 +1486,11 @@ export class CreatorBase extends Base
       this.doOnPageAdded(options.page);
     });
     survey.onGetMatrixRowActions.add((_, opt) => { updateMatrixRemoveAction(opt.question, opt.actions, opt.row); });
-    survey.onDragDropAllow.add(function (sender, options) {
+    survey.onDragDropAllow.add((sender, options) => {
       options.survey = sender;
-      this.onDragDropAllow.fire(self, options);
+      this.onDragDropAllow.fire(this, options);
     });
+
     this.setSurvey(survey);
     const currentPlugin = this.getPlugin(this.activeTab);
     if (!!currentPlugin && !!currentPlugin.update) {

--- a/packages/survey-creator-core/tests/creator-base.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base.tests.ts
@@ -1940,6 +1940,23 @@ test("creator.onActiveTabChaning", (): any => {
   expect(tabName).toEqual("logic");
   expect(creator.activeTab).toEqual("test");
 });
+test("creator.onDragDropAllow", (): any => {
+  const creator = new CreatorTester({});
+  let fired = false;
+  creator.onDragDropAllow.add((sender, options) => {
+    fired = true;
+  });
+
+  const survey = creator.survey;
+  const page = survey.addNewPage("page1");
+  const q1 = page.addNewQuestion("text", "q1");
+  const q2 = page.addNewQuestion("text", "q2");
+  const target = new QuestionTextModel("q1");
+  page.dragDropStart(q1, target);
+  page.dragDropMoveTo(q2, true);
+
+  expect(fired).toBeTruthy();
+});
 test("update tab content", (): any => {
   const creator = new CreatorTester({
     showTranslationTab: true,


### PR DESCRIPTION
see https://github.com/surveyjs/survey-creator/issues/2846

didn't create unit test because drag drop emulation doesn't make any sense in unit tests