### PR TITLE
Clarify docs in onUploadFile event

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -791,7 +791,9 @@ export class CreatorBase extends Base
    * <br/> sender the survey creator object that fires the event
    * <br/> There are two properties in options:
    * <br/> files the Javascript File objects array
-   * <br/> callback called on upload complete
+   * <br/> callback called on upload complete,
+   * <br/> which takes two string arguments:
+   * <br/> a status and an image link
    * @see uploadFile
    */
   public onUploadFile: Survey.Event<


### PR DESCRIPTION
I had a hard time figuring out how to upload files to a server (the examples were a bit outdated). The docs didn't specify the function signature for `options.callback`, so I added some details to make it easier for the next person :)