### PR TITLE
Recommendation: math.div($logic-space, 2) or calc($logic-space / 2)

### DIFF
--- a/packages/survey-creator/src/tabs/logic.scss
+++ b/packages/survey-creator/src/tabs/logic.scss
@@ -28,7 +28,7 @@ $logic-space: 20px;
   border-bottom-color: var(--secondary-border-color, $secondary-border-color);
   th,
   td {
-    padding: $logic-space / 2;
+    padding: calc($logic-space / 2);
   }
 }
 


### PR DESCRIPTION
DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($logic-space, 2) or calc($logic-space / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
31 │     padding: $logic-space / 2;
   │              ^^^^^^^^^^^^^^^^
   ╵
    stdin 31:14  root stylesheet