### PR TITLE
Bug - `window` reference causes issue in `next.js`

### DIFF
--- a/packages/survey-creator-core/src/components/simulator.ts
+++ b/packages/survey-creator-core/src/components/simulator.ts
@@ -153,7 +153,7 @@ export class SurveySimulatorModel extends Base {
   }
 }
 
-export var DEFAULT_MONITOR_DPI = (!!window ? window.devicePixelRatio : 1) * 96;
+export var DEFAULT_MONITOR_DPI = (typeof window !== "undefined" ? window.devicePixelRatio : 1) * 96;
 export var simulatorDevices = {
   desktop: {
     deviceType: "desktop",

--- a/packages/survey-creator/src/components/simulator.ts
+++ b/packages/survey-creator/src/components/simulator.ts
@@ -157,7 +157,7 @@ ko.components.register("survey-simulator", {
   template: templateHtml,
 });
 
-export var DEFAULT_MONITOR_DPI = (!!window ? window.devicePixelRatio : 1) * 96;
+export var DEFAULT_MONITOR_DPI = (window !== "undefined" ? window.devicePixelRatio : 1) * 96;
 export var simulatorDevices = {
   desktop: {
     deviceType: "desktop",

--- a/packages/survey-creator/src/components/simulator.ts
+++ b/packages/survey-creator/src/components/simulator.ts
@@ -157,7 +157,7 @@ ko.components.register("survey-simulator", {
   template: templateHtml,
 });
 
-export var DEFAULT_MONITOR_DPI = (window !== "undefined" ? window.devicePixelRatio : 1) * 96;
+export var DEFAULT_MONITOR_DPI = (typeof window !== "undefined" ? window.devicePixelRatio : 1) * 96;
 export var simulatorDevices = {
   desktop: {
     deviceType: "desktop",


### PR DESCRIPTION
I tried importing this library into a next.js project (with SSR) and this `window` reference causes an issue. 

```
error - ReferenceError: window is not defined
    at Module../src/components/simulator.ts (/node_modules/survey-creator-core/survey-creator-core.js:2949:27)
```

I see this issue has been brought up before: https://surveyjs.answerdesk.io/ticket/details/t8983/referenceerror-window-is-not-defined-while-importing-latest-survey-creator-react-version

The fix seems pretty simple—just changed the `!!window` to `typeof window !== "undefined"`. I was able to modify this file locally and test it and confirmed it worked.