### PR TITLE
#4183 Question Title Editor removes whitespaces when copying the text from a MS 365 Word Desktop

### DIFF
--- a/packages/survey-creator-angular/src/string-editor.component.html
+++ b/packages/survey-creator-angular/src/string-editor.component.html
@@ -7,7 +7,7 @@
         </div>
         <span class="svc-string-editor__input">
           <span role="textbox" *ngIf="!locString.hasHtml" class="sv-string-editor" spellcheck="false"
-              (focus)="onFocus($event)" (blur)="onBlur($event)"  (input)="baseModel.onInput($event)" (keydown)="baseModel.onKeyDown($event)" (keyup)="baseModel.onKeyUp($event)" (mouseup)="baseModel.onMouseUp($event)" (click)="edit($event)" [textContent]="editValue" [attr.aria-placeholder]="placeholder" [attr.contenteditable]="contentEditable" #container></span>
+              (focus)="onFocus($event)" (paste)="onPaste($event)" (blur)="onBlur($event)"  (input)="baseModel.onInput($event)" (keydown)="baseModel.onKeyDown($event)" (keyup)="baseModel.onKeyUp($event)" (mouseup)="baseModel.onMouseUp($event)" (click)="edit($event)" [textContent]="editValue" [attr.aria-placeholder]="placeholder" [attr.contenteditable]="contentEditable" #container></span>
           <span role="textbox" *ngIf="locString.hasHtml" class="sv-string-editor sv-string-editor--html" spellcheck="false"
           (focus)="onFocus($event)" (blur)="onBlur($event)" (keydown)="baseModel.onKeyDown($event)" (keyup)="baseModel.onKeyUp($event)" (mouseup)="baseModel.onMouseUp($event)"
           (click)="edit($event)" [attr.aria-placeholder]="placeholder" [attr.contenteditable]="contentEditable" [innerHtml]="editValue | safeHtml" #container></span>

--- a/packages/survey-creator-angular/src/string-editor.component.ts
+++ b/packages/survey-creator-angular/src/string-editor.component.ts
@@ -79,6 +79,9 @@ export class StringEditorComponent extends CreatorModelComponent<StringEditorVie
     this.baseModel.onFocus(event);
     this.justFocused = true;
   }
+  public onPaste(event: any): void {
+    this.baseModel.onPaste(event);
+  }
   public done(event: any): void {
     this.baseModel.done(event);
     (<any>this.locString).__isEditing = false;

--- a/packages/survey-creator-core/src/components/string-editor.ts
+++ b/packages/survey-creator-core/src/components/string-editor.ts
@@ -395,6 +395,16 @@ export class StringEditorViewModelBase extends Base {
     event.stopImmediatePropagation();
     event.preventDefault();
   }
+
+  public onPaste(event: ClipboardEvent) {
+    if (this.editAsText) {
+      event.preventDefault();
+      // get text representation of clipboard
+      var text = event.clipboardData.getData("text/plain");
+      // insert text manually
+      document.execCommand("insertHTML", false, text);
+    }
+  }
   public onKeyDown(event: KeyboardEvent): boolean {
     if (event.keyCode === 13) {
       this.blurEditor();

--- a/packages/survey-creator-knockout/src/string-editor.html
+++ b/packages/survey-creator-knockout/src/string-editor.html
@@ -8,7 +8,7 @@
             <!-- ko ifnot: koHasHtml -->
             <!-- ko template: {afterRender: afterRender} -->
             <span role="textbox" class="sv-string-editor" spellcheck="false"
-                data-bind="text: editValue, event: { focus: onFocus, blur: onBlur, input: onInput, keydown: onKeyDown, keyup: onKeyUp, mouseup: onMouseUp, compositionstart: onCompositionStart, compositionend: onCompositionEnd }, click: edit, attr: { 'aria-placeholder': placeholder, 'aria-label': this.placeholder || 'content editable', contenteditable: contentEditable }"></span>
+                data-bind="text: editValue, event: { focus: onFocus, paste: onPaste, blur: onBlur, input: onInput, keydown: onKeyDown, keyup: onKeyUp, mouseup: onMouseUp, compositionstart: onCompositionStart, compositionend: onCompositionEnd }, click: edit, attr: { 'aria-placeholder': placeholder, 'aria-label': this.placeholder || 'content editable', contenteditable: contentEditable }"></span>
             <!-- /ko -->
             <!-- /ko -->
             <!-- ko if: koHasHtml -->

--- a/packages/survey-creator-knockout/src/string-editor.ts
+++ b/packages/survey-creator-knockout/src/string-editor.ts
@@ -79,6 +79,9 @@ export class StringEditorViewModel {
   public onInput(sender: StringEditorViewModel, event: any): void {
     this.baseModel.onInput(event);
   }
+  public onPaste(sender: StringEditorViewModel, event: any): void {
+    this.baseModel.onPaste(event);
+  }
 
   public onBlur(sender: StringEditorViewModel, event: any): void {
     event.currentTarget.spellcheck = false;

--- a/packages/survey-creator-react/src/StringEditor.tsx
+++ b/packages/survey-creator-react/src/StringEditor.tsx
@@ -85,6 +85,9 @@ export class SurveyLocStringEditor extends CreatorModelElement<any, any> {
   private onInput = (event: any) => {
     this.baseModel.onInput(event.nativeEvent);
   };
+  private onPaste = (event: any) => {
+    this.baseModel.onPaste(event.nativeEvent);
+  };
   private justFocused = false;
   private onFocus = (event: any) => {
     this.baseModel.onFocus(event.nativeEvent);
@@ -155,6 +158,7 @@ export class SurveyLocStringEditor extends CreatorModelElement<any, any> {
           // style={this.style}
           onBlur={this.onBlur}
           onInput={this.onInput}
+          onPaste={this.onPaste}
           onCompositionStart={this.onCompositionStart}
           onCompositionEnd={this.onCompositionEnd}
           onFocus={this.onFocus}


### PR DESCRIPTION
Fixes #4183

Unfortunately this issue fix **can not be tested automatically** with Jest or TestCafe.
You can test it manually.
Build and run SurveyCreator.
Open Chrome console and execute this code:
```
document.addEventListener('copy', function(e){
  e.clipboardData.setData('text/html', '<span>s\nd</span>');
  e.clipboardData.setData('text/plain', 's d');
  e.preventDefault(); // default behaviour is to copy any selected text
});
```
Click on any question title. Press `Crtl-C` (the clipboard data will be filled in code you entered in console).
Press `Ctrl-V` and see the pasted text.
If you see "s d" with whitespace between, all is ok.
If you see "sd" _without_ whitespaces between, it is going wrong and works as not expected.
