### PR TITLE
chore(types): made model optional

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -81,7 +81,7 @@ export interface ICreatorPlugin {
   canDeactivateAsync?: (onSuccess: () => void) => void;
   dispose?: () => void;
   onDesignerSurveyPropertyChanged?: (obj: Base, propName: string) => void;
-  model: Base;
+  model?: any;
 }
 //Obsolete
 export class CreatorAction extends Action {
@@ -2145,7 +2145,7 @@ export class CreatorBase extends Base
     }
     var parent: IPanel = this.currentPage;
     if (this.pageEditMode === "bypage") {
-      const desigerTab = this.getPlugin("designer").model as any;
+      const desigerTab = this.getPlugin<TabDesignerPlugin>("designer").model;
       const pagesController = desigerTab.pagesController;
       parent = pagesController.page2Display;
     }

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -81,7 +81,6 @@ export interface ICreatorPlugin {
   canDeactivateAsync?: (onSuccess: () => void) => void;
   dispose?: () => void;
   onDesignerSurveyPropertyChanged?: (obj: Base, propName: string) => void;
-  model?: any;
 }
 //Obsolete
 export class CreatorAction extends Action {
@@ -1223,7 +1222,7 @@ export class CreatorBase extends Base
     if (!this.canSwitchViewType()) return false;
     const plugin = this.activatePlugin(viewName);
     this.viewType = viewName;
-    this.onActiveTabChanged.fire(this, { tabName: viewName, plugin: plugin, model: !!plugin ? plugin.model : undefined });
+    this.onActiveTabChanged.fire(this, { tabName: viewName, plugin: plugin });
     return true;
   }
   private canSwitchViewType(): boolean {

--- a/packages/survey-creator-core/src/plugins/undo-redo/index.ts
+++ b/packages/survey-creator-core/src/plugins/undo-redo/index.ts
@@ -4,7 +4,7 @@ import { UndoRedoController } from "./undo-redo-controller";
 import { UndoRedoManager } from "./undo-redo-manager";
 
 export class UndoRedoPlugin implements ICreatorPlugin {
-
+  public model: UndoRedoController;
   constructor(private creator: CreatorBase) {
     this.model = new UndoRedoController(creator);
     this.model.createActions().forEach(action => creator.toolbar.actions.push(action));


### PR DESCRIPTION
This PR changes the `ICreatorPlugin` interface.
Instead of requiring a `model` property of type `Base` to be present, it is changed to be optional and of type `any`.

I'm working on a typescript project (specifically integrating SurveyJS cleanly with Svelte).

When implementing an custom plugin tab I noticed that I was required to provide this property, but it is never used in any meaningful way by the creator code.