### PR TITLE
fix(logic): Assign default classes by css type

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/logic-item-editor.ts
+++ b/packages/survey-creator-core/src/components/tabs/logic-item-editor.ts
@@ -240,7 +240,7 @@ export class LogicItemEditor extends PropertyEditorSetupValue {
       options.cssClasses.onError = "svc-logic-operator--error";
     }
     if (options.question.name === "setValue") {
-      assignDefaultV2Classes(options.cssClasses, options.question.getType());
+      assignDefaultV2Classes(options.cssClasses, options.question.getCssType());
       options.cssClasses.mainRoot += " svc-logic-question-value sd-element--with-frame";
     }
     if (options.question.name === "removeAction") {

--- a/packages/survey-creator-core/src/property-grid/condition-survey.ts
+++ b/packages/survey-creator-core/src/property-grid/condition-survey.ts
@@ -942,7 +942,7 @@ export class ConditionEditor extends PropertyEditorSetupValue {
     }
     // options.cssClasses.mainRoot += "sd-question sd-row__question";
     if (options.question.name === "questionValue" || options.question.isContentElement) {
-      assignDefaultV2Classes(options.cssClasses, options.question.getType());
+      assignDefaultV2Classes(options.cssClasses, options.question.getCssType());
       options.cssClasses.mainRoot += " svc-logic-question-value sd-element--with-frame";
       options.cssClasses.error.root = "svc-logic-operator__error";
     }


### PR DESCRIPTION
`getCssType` is the method exposed on `Question` to find that question's css in the default stylesheets.

See relevant reference from survey-core here: https://github.com/surveyjs/survey-library/blob/master/src/question.ts#L919