### PR TITLE
#4412 When the creator.inplaceEditForValues option is enabled, the None and Other item text is not correctly updated

### DIFF
--- a/packages/survey-creator-core/src/components/string-editor.ts
+++ b/packages/survey-creator-core/src/components/string-editor.ts
@@ -369,7 +369,9 @@ export class StringEditorViewModelBase extends Base {
     if (this.locString.text != clearedText &&
       !(!this.locString.text && clearedText == this.locString.calculatedText)) {
       if (!this.errorText) {
-        if (this.locString.owner instanceof ItemValue && this.creator.inplaceEditForValues) {
+        if (this.locString.owner instanceof ItemValue &&
+          this.creator.inplaceEditForValues &&
+          ["noneText", "otherText", "selectAllText"].indexOf(this.locString.name) == -1) {
           const itemValue = <ItemValue>this.locString.owner;
           if(itemValue.value !== clearedText) {
             if(!!itemValue.locOwner && !!itemValue.ownerPropertyName) {

--- a/packages/survey-creator-core/tests/string-editor.tests.ts
+++ b/packages/survey-creator-core/tests/string-editor.tests.ts
@@ -303,6 +303,15 @@ test("Test string editor inplaceEditForValues", (): any => {
   expect(itemValue.value).toEqual("item1");
   expect(itemValue.text).toEqual("newItem");
 
+  var otherItem;
+  const q1 = <QuestionRadiogroupModel>creator.survey.getQuestionByName("q0");
+  otherItem = q1.otherItem;
+  var seChoiceOther = new StringEditorViewModelBase(otherItem.locText, creator);
+  expect(otherItem.text).toEqual("Other (describe)");
+  seChoiceOther.onBlur({ target: { innerText: "Other changed", innerHTML: "Other changed", setAttribute: () => { }, removeAttribute: () => { } } });
+  expect(otherItem.locText.text).toEqual("Other changed");
+  expect(q0.otherText).toEqual("Other changed");
+
   creator.inplaceEditForValues = true;
   seChoice.onBlur({ target: { innerText: "newItemValue", innerHTML: "newItemValue", setAttribute: () => { }, removeAttribute: () => { } } });
   expect(itemValue.locText.text).toEqual("newItem");


### PR DESCRIPTION
Fixes #4412