### PR TITLE
Fix the addNewQuestion string

### DIFF
--- a/packages/survey-creator-core/src/localization/french.ts
+++ b/packages/survey-creator-core/src/localization/french.ts
@@ -142,7 +142,7 @@ var frenchTranslation = {
     bold: "Gras",
     italic: "Italique",
     underline: "Souligné",
-    addNewQuestion: "Ajouter {0}",
+    addNewQuestion: "Ajouter Question",
     selectPage: "Sélectionner une page...",
     carryForwardChoicesCopied: "Les choix sont copiés à partir de",
     htmlPlaceHolder: "Le contenu HTML se trouvera ici.",


### PR DESCRIPTION
In English localization: 
https://github.com/surveyjs/survey-creator/blob/master/packages/survey-creator-core/src/localization/english.ts#L149
```
addNewQuestion: "Add Question",
```
Based on a user inquiry at https://surveyjs.answerdesk.io/internal/ticket/details/T14174#236c5536-80fe-455c-ba4e-4a39545a8396.