### PR TITLE
The onElementDeleting event is not fired when removing elements (e.g.…

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -3088,7 +3088,7 @@ export class CreatorBase extends Base
     collection: Array<Base>,
     item: Base
   ): boolean {
-    if((<any>item).isPage && !this.checkOnElementDeleting(item)) return false;
+    if((<any>item)?.isPage && !this.checkOnElementDeleting(item)) return false;
     if (this.onCollectionItemDeleting.isEmpty) return true;
     const options = {
       obj: obj,

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -2589,13 +2589,7 @@ export class CreatorBase extends Base
   }
   @undoRedoTransaction()
   protected deleteObject(obj: any) {
-    var options = {
-      element: obj,
-      elementType: SurveyHelper.getObjectType(obj),
-      allowing: true
-    };
-    this.onElementDeleting.fire(this, options);
-    if (!options.allowing) return;
+    if (!this.checkOnElementDeleting(obj)) return;
     this.deleteObjectCore(obj);
   }
   protected updateConditionsOnRemove(obj: any) {
@@ -2612,7 +2606,15 @@ export class CreatorBase extends Base
       logic.removeQuestion(questions[i].getValueName());
     }
   }
-
+  private checkOnElementDeleting(obj: any): boolean {
+    const options = {
+      element: obj,
+      elementType: SurveyHelper.getObjectType(obj),
+      allowing: true
+    };
+    this.onElementDeleting.fire(this, options);
+    return options.allowing;
+  }
   public isElementSelected(element: Base): boolean {
     if (!element || element.isDisposed) return false;
     return element.getPropertyValue("isSelectedInDesigner");
@@ -3086,8 +3088,9 @@ export class CreatorBase extends Base
     collection: Array<Base>,
     item: Base
   ): boolean {
+    if((<any>item).isPage && !this.checkOnElementDeleting(item)) return false;
     if (this.onCollectionItemDeleting.isEmpty) return true;
-    var options = {
+    const options = {
       obj: obj,
       property: property,
       propertyName: property.name,

--- a/packages/survey-creator-core/tests/property-grid/property-grid-creator-events.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid-creator-events.tests.ts
@@ -1,0 +1,27 @@
+import { QuestionMatrixDynamicModel, Base } from "survey-core";
+import { PropertyGridModelTester } from "./property-grid.base";
+import { CreatorTester } from "../creator-tester";
+
+test("creator.onElementDeleting", () => {
+  const creator = new CreatorTester();
+  creator.onElementDeleting.add((sender, options) => {
+    if(options.element.isPage) {
+      options.allowing = creator.survey.pages.indexOf(options.element) > 1;
+    }
+  });
+  const survey = creator.survey;
+  survey.addNewPage("page1");
+  survey.addNewPage("page2");
+  survey.addNewPage("page3");
+  var propertyGrid = new PropertyGridModelTester(survey, creator);
+  var pagesQuestion = <QuestionMatrixDynamicModel>(
+    propertyGrid.survey.getQuestionByName("pages")
+  );
+  const rows = pagesQuestion.visibleRows;
+  pagesQuestion.removeRowUI(rows[0]);
+  expect(survey.pages).toHaveLength(3);
+  pagesQuestion.removeRowUI(rows[1]);
+  expect(survey.pages).toHaveLength(3);
+  pagesQuestion.removeRowUI(rows[2]);
+  expect(survey.pages).toHaveLength(2);
+});


### PR DESCRIPTION
…, choices or pages) within a Property Grid fix #4801