### PR TITLE
Update documentation to reflect missing property

### DIFF
--- a/docs/customize-survey-creation-process.md
+++ b/docs/customize-survey-creation-process.md
@@ -21,15 +21,16 @@ Adorners are design-surface controls that allow Survey Creator users to manipula
 
 You can control the visibility of adorners using the `onElementAllowOperations` event. As the second parameter, the event handler accepts an object that exposes the following Boolean properties:
 
-| Property | Description    |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| `allowChangeRequired`  | Shows or hides the adorner that makes the question required. |
-| `allowChangeType`      | Shows or hides the adorner that changes the survey element type.      |
+| Property               | Description                                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowChangeRequired`  | Shows or hides the adorner that makes the question required.                                                                                                                                            |
+| `allowChangeType`      | Shows or hides the adorner that changes the survey element type.                                                                                                                                        |
 | `allowChangeInputType` | Shows or hides the adorner that changes the [`inputType`](https://surveyjs.io/form-library/documentation/api-reference/text-entry-question-model#inputType) property of Single-Line Input questions.    |
-| `allowCopy`    | Shows or hides the adorner that duplicates the survey element.  |
-| `allowDelete`  | Shows or hides the adorner that deletes the survey element.  |
-| `allowDragging`  | Shows or hides the adorner that allows users to drag and drop survey elements.      |
-| `allowEdit`    | Shows or hides the adorners that allow users to edit survey element properties on the design surface. If you disable this property, users can edit survey element properties only in the Property Grid. |
+| `allowCopy`            | Shows or hides the adorner that duplicates the survey element.                                                                                                                                          |
+| `allowDelete`          | Shows or hides the adorner that deletes the survey element.                                                                                                                                             |
+| `allowDragging`        | Shows or hides the adorner that allows users to drag and drop survey elements.                                                                                                                          |
+| `allowEdit`            | Shows or hides the adorners that allow users to edit survey element properties on the design surface. If you disable this property, users can edit survey element properties only in the Property Grid. |
+| `allowShowEditor`      | Shows or hides the adorner that edits the survey element                                                                                                                                                |
 
 The following code hides the "Change Type" adorner for Dropdown questions:
 
@@ -61,13 +62,13 @@ SurveyCreator.removeAdorners();
 
 Survey Creator raises events when users add new elements to a survey. You can handle these events to customize the elements.
 
-| Event name | Raised when |
-| ---------- | ----------- |
-| [`onQuestionAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onQuestionAdded) | Raised when users add a question to the survey. |
-| [`onPanelAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onPanelAdded) | Raised when users add a panel to the survey. |
-| [`onPageAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onPageAdded) | Raised when users add a page to the survey. |
+| Event name                                                                                                      | Raised when                                                                                                                                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`onQuestionAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onQuestionAdded)         | Raised when users add a question to the survey.                                                                                                                                                                                          |
+| [`onPanelAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onPanelAdded)               | Raised when users add a panel to the survey.                                                                                                                                                                                             |
+| [`onPageAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onPageAdded)                 | Raised when users add a page to the survey.                                                                                                                                                                                              |
 | [`onMatrixColumnAdded`](https://surveyjs.io/Documentation/Survey-Creator/?id=surveycreator#onMatrixColumnAdded) | Raised when users add a column to the [Matrix Dropdown](https://surveyjs.io/Documentation/Library?id=questionmatrixdropdownmodel) or [Matrix Dynamic](https://surveyjs.io/Documentation/Library?id=questionmatrixdynamicmodel) question. |
-| [`onItemValueAdded`](https://surveyjs.io/Documentation/Survey-Creator?id=surveycreator#onItemValueAdded) | Raised when users add a new item value (column, row, choice). |
+| [`onItemValueAdded`](https://surveyjs.io/Documentation/Survey-Creator?id=surveycreator#onItemValueAdded)        | Raised when users add a new item value (column, row, choice).                                                                                                                                                                            |
 
 The code below shows how you can handle the `onQuestionAdded` event to customize the default question name:
 


### PR DESCRIPTION
Documenting property `allowShowEditor` it can be beneficial for people to know how to show or hides the adorner that edits the survey element, instead of disabling all the adorners related to editing. 