### PR TITLE
Theme builder API enchancements 1

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/theme-builder.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-builder.ts
@@ -646,7 +646,7 @@ export class ThemeBuilder extends Base {
   }
   findSuitableTheme(themeName: string): ITheme {
     let probeThemeFullName = getThemeFullName({ themeName: themeName, colorPalette: this.themePalette, isPanelless: this.themeMode === "lightweight" } as any);
-    return findSuitableTheme(themeName, probeThemeFullName);
+    return findSuitableTheme(themeName, this.themePalette, this.themeMode, probeThemeFullName);
   }
   private patchFileEditors(survey: SurveyModel) {
     const questionsToPatch = survey.getAllQuestions(false, false, true).filter(q => q.getType() == "fileedit");

--- a/packages/survey-creator-core/src/components/tabs/theme-builder.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-builder.ts
@@ -422,6 +422,7 @@ export class ThemeBuilder extends Base {
       if (availebleThemes.indexOf(themeChooser.value) === -1) {
         themeChooser.value = ThemeBuilder.DefaultTheme.themeName;
       }
+      this.updatePropertyGridEditorsAvailability();
     }
   }
 
@@ -762,8 +763,24 @@ export class ThemeBuilder extends Base {
   }
   private updatePropertyGridEditorsAvailability() {
     const isCustomTheme = PredefinedThemes.indexOf(this.themeName) === -1;
-    this.themeEditorSurvey.getQuestionByName("themeMode").readOnly = isCustomTheme;
-    this.themeEditorSurvey.getQuestionByName("themePalette").readOnly = isCustomTheme;
+    let customThemeHasModeVariations = false;
+    let customThemeHasPaletteVariations = false;
+    if (isCustomTheme) {
+      const registeredThemes = Object.keys(Themes);
+      let themeLight = this.themeName + "-light";
+      let themeDark = this.themeName + "-dark";
+      if (this.themeMode !== "panels") {
+        themeLight += "-panelless";
+        themeDark += "-panelless";
+      }
+      customThemeHasPaletteVariations = registeredThemes.indexOf(themeLight) !== -1 && registeredThemes.indexOf(themeDark) !== -1;
+
+      let themePanels = this.themeName + "-" + this.themePalette;
+      let themePanelless = themePanels + "-panelless";
+      customThemeHasModeVariations = registeredThemes.indexOf(themePanels) !== -1 && registeredThemes.indexOf(themePanelless) !== -1;
+    }
+    this.themeEditorSurvey.getQuestionByName("themeMode").readOnly = isCustomTheme && !customThemeHasModeVariations;
+    this.themeEditorSurvey.getQuestionByName("themePalette").readOnly = isCustomTheme && !customThemeHasPaletteVariations;
 
     let canModify = !this.surveyProvider.readOnly;
     const options = {

--- a/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
@@ -394,7 +394,8 @@ export class ThemeTabPlugin implements ICreatorPlugin {
         this.availableThemes = this.availableThemes.concat([theme.themeName]);
       }
     } else {
-      this.availableThemes = this.availableThemes
+      // eslint-disable-next-line no-self-assign
+      this.availableThemes = this.availableThemes;
     }
     return fullThemeName;
   }

--- a/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
@@ -399,7 +399,7 @@ export class ThemeTabPlugin implements ICreatorPlugin {
     }
     return fullThemeName;
   }
-  public removeTheme(themeAccessor: string | ITheme): void {
+  public removeTheme(themeAccessor: string | ITheme, withModifications = false): void {
     const themeToDelete = typeof themeAccessor === "string" ? Themes[themeAccessor] : themeAccessor;
     const fullThemeName = typeof themeAccessor === "string" ? themeAccessor : getThemeFullName(themeToDelete);
     if (!!themeToDelete) {
@@ -408,8 +408,11 @@ export class ThemeTabPlugin implements ICreatorPlugin {
         ThemeBuilder.DefaultTheme = Themes["default-light"] || Themes[Object.keys(Themes)[0]];
       }
       const registeredThemeNames = Object.keys(Themes);
-      let themeModificationsExist = registeredThemeNames.some(themeName => themeName.indexOf(themeToDelete.themeName) === 0);
-      if (!themeModificationsExist) {
+      let themeModifications = registeredThemeNames.filter(themeName => themeName.indexOf(themeToDelete.themeName + "-") === 0);
+      if (withModifications && themeModifications.length > 0) {
+        themeModifications.forEach(themeModificationFullName => delete Themes[themeModificationFullName]);
+      }
+      if (withModifications || themeModifications.length === 0) {
         const themeIndex = this._availableThemes.indexOf(themeToDelete.themeName);
         if (themeIndex !== -1) {
           const availableThemes = this.availableThemes;
@@ -426,9 +429,9 @@ export class ThemeTabPlugin implements ICreatorPlugin {
     return this.getThemeChanges();
   }
   public getThemeChanges() {
-    const fullTheme = this.creator.theme;
+    const fullTheme: ITheme = this.creator.theme;
     let probeThemeFullName = getThemeFullName(fullTheme);
-    const baseTheme = findSuitableTheme(fullTheme.themeName, probeThemeFullName);
+    const baseTheme = findSuitableTheme(fullTheme.themeName, fullTheme.colorPalette, fullTheme.isPanelless ? "lightweight" : "panels", probeThemeFullName);
     const themeChanges: ITheme = getObjectDiffs(fullTheme, baseTheme);
     Object.keys(themeChanges).forEach(propertyName => {
       if (propertyName.toLowerCase().indexOf("background") !== -1) {

--- a/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-plugin.ts
@@ -229,7 +229,7 @@ export class ThemeTabPlugin implements ICreatorPlugin {
     items.push(this.redoAction);
 
     this.saveThemeAction = new Action({
-      id: "svd-save",
+      id: "svd-save-theme",
       iconName: "icon-save",
       action: () => {
         this.creator.doSaveTheme();
@@ -393,6 +393,8 @@ export class ThemeTabPlugin implements ICreatorPlugin {
       } else {
         this.availableThemes = this.availableThemes.concat([theme.themeName]);
       }
+    } else {
+      this.availableThemes = this.availableThemes
     }
     return fullThemeName;
   }

--- a/packages/survey-creator-core/src/components/tabs/themes.ts
+++ b/packages/survey-creator-core/src/components/tabs/themes.ts
@@ -45,18 +45,18 @@ export const PredefinedColors = {
   }
 };
 
-export function findSuitableTheme(themeName: string, probeThemeFullName: string) {
+export function findSuitableTheme(themeName: string, themePalette: string, themeMode: string, probeThemeFullName: string) {
   let suitableTheme = Themes[probeThemeFullName];
   if (!!suitableTheme) {
     return suitableTheme;
   }
-  const appropriateThemeNames = Object.keys(Themes).filter(fullName => fullName.indexOf(themeName) === 0);
+  const appropriateThemeNames = Object.keys(Themes).filter(fullName => fullName.indexOf(themeName + "-") === 0);
   for (let fullThemeName of appropriateThemeNames) {
-    if (fullThemeName.indexOf(themeName + "-" + this.themePalette) === 0) {
-      probeThemeFullName = themeName + "-" + this.themePalette;
+    if (fullThemeName.indexOf(themeName + "-" + themePalette) === 0) {
+      probeThemeFullName = themeName + "-" + themePalette;
     }
-    if (fullThemeName.indexOf(themeName + "-" + this.themePalette + (this.themeMode === "lightweight" ? "-panelless" : "")) === 0) {
-      probeThemeFullName = themeName + "-" + this.themePalette + (this.themeMode === "lightweight" ? "-panelless" : "");
+    if (fullThemeName.indexOf(themeName + "-" + themePalette + (themeMode === "lightweight" ? "-panelless" : "")) === 0) {
+      probeThemeFullName = themeName + "-" + themePalette + (themeMode === "lightweight" ? "-panelless" : "");
     }
   }
   return Themes[probeThemeFullName] || Themes[appropriateThemeNames[0]];

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -3477,7 +3477,7 @@ export class CreatorBase extends Base
           this._updateSaveActions();
         });
       }
-    }
+    };
     if (this.state === "modified") {
       this._doSaveCore(() => {
         themeSaveHandler();

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -281,6 +281,10 @@ export class CreatorBase extends Base
   public get toolbar(): ActionContainer {
     return this.toolbarValue;
   }
+  protected _findAction(id: string): Action {
+    return this.toolbarItems.filter(a => a.id === id)[0];
+  }
+
   public dragDropSurveyElements: DragDropSurveyElements;
   public dragDropChoices: DragDropChoices;
 
@@ -1252,7 +1256,7 @@ export class CreatorBase extends Base
     }
   }
 
-  public doSaveTheme() {
+  private _doSaveThemeCore(onSaveComplete?: () => void) {
     this.setState("saving");
     if (this.saveThemeFunc) {
       this.saveNo++;
@@ -1267,7 +1271,15 @@ export class CreatorBase extends Base
             this.notify(this.getLocString("ed.saveError"), "error");
           }
         }
+        onSaveComplete && onSaveComplete();
       });
+    }
+  }
+  public doSaveTheme() {
+    if (this.saveSurveyAndTheme) {
+      this.doSaveSurveyAndTheme();
+    } else {
+      this._doSaveThemeCore();
     }
   }
 
@@ -1546,6 +1558,7 @@ export class CreatorBase extends Base
     this.updateToolboxIsCompact();
     this.initTabs();
     this.initDragDrop();
+    this.saveSurveyAndTheme = this.options.saveSurveyAndTheme;
     this.isTouch = IsTouch;
     const expandAction = this.sidebar.getExpandAction();
     !!expandAction && this.toolbar.actions.push(expandAction);
@@ -2325,11 +2338,7 @@ export class CreatorBase extends Base
     this.onStateChanged.fire(this, { val: value });
     if (!!value) {
       this.notify(this.getLocString("ed." + value));
-      const actions = this.toolbarItems.filter(a => a.id === "svd-save");
-      if (Array.isArray(actions) && actions.length > 0) {
-        actions[0].enabled = this.state === "modified";
-        actions[0].active = this.state === "modified";
-      }
+      this._updateSaveActions();
     }
   }
   public onStateChanged: CreatorEvent = new CreatorEvent();
@@ -3420,7 +3429,7 @@ export class CreatorBase extends Base
     }, this.autoSaveDelay);
   }
   saveNo: number = 0;
-  public doSave() {
+  private _doSaveCore(onSaveComplete?: () => void) {
     this.setState("saving");
     if (this.saveSurveyFunc) {
       this.saveNo++;
@@ -3434,9 +3443,78 @@ export class CreatorBase extends Base
             this.notify(this.getLocString("ed.saveError"), "error");
           }
         }
+        onSaveComplete && onSaveComplete();
       });
     }
   }
+  public doSave() {
+    if (this.saveSurveyAndTheme) {
+      this.doSaveSurveyAndTheme();
+    } else {
+      this._doSaveCore();
+    }
+  }
+
+  private _updateSaveActions() {
+    const action = this._findAction("svd-save");
+    if (action) {
+      action.enabled = this.state === "modified";
+      action.active = this.state === "modified";
+    }
+    if (this.saveSurveyAndTheme) {
+      const action = this._findAction("svd-save-theme");
+      if (action) {
+        action.enabled = this.isThemeModified;
+        action.active = this.isThemeModified;
+      }
+    }
+  }
+
+  public doSaveSurveyAndTheme() {
+    const themeSaveHandler = () => {
+      if (this.isThemeModified) {
+        this._doSaveThemeCore(() => {
+          this._updateSaveActions();
+        });
+      }
+    }
+    if (this.state === "modified") {
+      this._doSaveCore(() => {
+        themeSaveHandler();
+      });
+    } else themeSaveHandler();
+  }
+
+  protected _syncSaveActions = (sender: any, options: any) => {
+    const saveAction = this._findAction("svd-save");
+    const saveThemeAction = this._findAction("svd-save-theme");
+    if (!saveAction || !saveThemeAction) {
+      return;
+    }
+    if (sender === this) {
+      saveThemeAction.enabled = saveAction.enabled;
+    } else {
+      saveAction.enabled = saveThemeAction.enabled;
+    }
+  }
+
+  @property({
+    defaultValue: false, onSet(val, target: CreatorBase) {
+      let themeTabPlugin: ThemeTabPlugin = target.getPlugin<ThemeTabPlugin>("theme");
+      if (!themeTabPlugin) {
+        return;
+      }
+      if (val) {
+        target.onModified.add(target._syncSaveActions);
+        themeTabPlugin.onThemeModified.add(target._syncSaveActions);
+        themeTabPlugin.onThemeSelected.add(target._syncSaveActions);
+      } else {
+        target.onModified.remove(target._syncSaveActions);
+        themeTabPlugin.onThemeModified.remove(target._syncSaveActions);
+        themeTabPlugin.onThemeSelected.remove(target._syncSaveActions);
+      }
+    },
+  }) saveSurveyAndTheme: boolean;
 
   /**
    * Specifies whether to display a button that saves the survey or theme (executes the [`saveSurveyFunc`](https://surveyjs.io/survey-creator/documentation/api-reference/survey-creator#saveSurveyFunc) or [`saveThemeFunc`](https://surveyjs.io/survey-creator/documentation/api-reference/survey-creator#saveThemeFunc) function).

--- a/packages/survey-creator-core/tests/tabs/integration.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/integration.tests.ts
@@ -1,0 +1,71 @@
+import { Action } from "survey-core";
+import { TabDesignerPlugin } from "../../src/components/tabs/designer-plugin";
+import { ThemeBuilder } from "../../src/components/tabs/theme-builder";
+export { QuestionFileEditorModel } from "../../src/custom-questions/question-file";
+export { QuestionSpinEditorModel } from "../../src/custom-questions/question-spin-editor";
+export { QuestionColorModel } from "../../src/custom-questions/question-color";
+import { ThemeTabPlugin } from "../../src/components/tabs/theme-plugin";
+import { CreatorTester } from "../creator-tester";
+
+test("saveSurvey and saveTheme actions integration", (): any => {
+  const creator: CreatorTester = new CreatorTester({ showThemeTab: true, saveSurveyAndTheme: true });
+  let saveCount = 0;
+  creator.saveSurveyFunc = () => {
+    saveCount++;
+  };
+  let saveThemeCount = 0;
+  creator.saveThemeFunc = (saveNo, callback) => {
+    saveThemeCount++;
+    callback(saveNo, "success");
+  };
+  creator.JSON = { questions: [{ type: "text", name: "q1" }] };
+  const designerPlugin: TabDesignerPlugin = <TabDesignerPlugin>creator.getPlugin("designer");
+  const saveSurveyAction = designerPlugin["saveSurveyAction"] as Action;
+  const themePlugin: ThemeTabPlugin = <ThemeTabPlugin>creator.getPlugin("theme");
+  const saveThemeAction = themePlugin["saveThemeAction"] as Action;
+
+  expect(saveCount).toBe(0);
+  expect(saveThemeCount).toBe(0);
+  expect(saveSurveyAction.visible).toBeTruthy();
+  expect(saveSurveyAction.enabled).toBeFalsy();
+  expect(saveThemeAction.visible).toBeFalsy();
+  expect(saveThemeAction.enabled).toBeFalsy();
+
+  creator.activeTab = "theme";
+  expect(saveSurveyAction.visible).toBeFalsy();
+  expect(saveSurveyAction.enabled).toBeFalsy();
+  expect(saveThemeAction.visible).toBeTruthy();
+  expect(saveThemeAction.enabled).toBeFalsy();
+
+  const themeSurveyTab = themePlugin.model as ThemeBuilder;
+  const themeEditor = themeSurveyTab.themeEditorSurvey;
+  themeEditor.getQuestionByName("--sjs-primary-backcolor").value = "some val";
+  expect(saveSurveyAction.enabled).toBeTruthy();
+  expect(saveThemeAction.enabled).toBeTruthy();
+
+  saveThemeAction.action();
+  expect(saveSurveyAction.visible).toBeFalsy();
+  expect(saveSurveyAction.enabled).toBeFalsy();
+  expect(saveThemeAction.visible).toBeTruthy();
+  expect(saveThemeAction.enabled).toBeFalsy();
+  expect(saveCount).toBe(0);
+  expect(saveThemeCount).toBe(1);
+
+  creator.activeTab = "designer";
+  expect(saveSurveyAction.visible).toBeTruthy();
+  expect(saveSurveyAction.enabled).toBeFalsy();
+  expect(saveThemeAction.visible).toBeFalsy();
+  expect(saveThemeAction.enabled).toBeFalsy();
+
+  creator.survey.title = "Changed";
+  expect(saveSurveyAction.enabled).toBeTruthy();
+  expect(saveThemeAction.enabled).toBeTruthy();
+
+  saveSurveyAction.action();
+  expect(saveSurveyAction.visible).toBeTruthy();
+  expect(saveSurveyAction.enabled).toBeFalsy();
+  expect(saveThemeAction.visible).toBeFalsy();
+  expect(saveThemeAction.enabled).toBeFalsy();
+  expect(saveCount).toBe(1);
+  expect(saveThemeCount).toBe(1);
+});

--- a/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
@@ -318,7 +318,7 @@ test("fontsettings: fontsettingsFromCssVariable", () => {
   const survey = new SurveyModel({
     elements: [{ type: "fontsettings", name: "questiontitle" }],
   });
-  const question = survey.findQuestionByName("questiontitle");
+  const question = survey.findQuestionByName("questiontitle") as Question;
   expect(question.value).toEqual({});
 
   fontsettingsFromCssVariable(question, {
@@ -344,7 +344,7 @@ test("fontsettings: fontsettingsFromCssVariable - default colors", () => {
   const survey = new SurveyModel({
     elements: [{ type: "fontsettings", name: "questiontitle" }],
   });
-  const question = survey.findQuestionByName("questiontitle");
+  const question = survey.findQuestionByName("questiontitle") as Question;
   expect(question.value).toEqual({});
 
   fontsettingsFromCssVariable(question, {}, "rgba(0, 0, 0, 0.91)", "rgba(0, 0, 0, 0.45)");
@@ -2445,4 +2445,138 @@ test("saveTheme action", (): any => {
   expect(themePlugin["saveThemeAction"].enabled).toBeFalsy();
   expect(saveCount).toBe(0);
   expect(saveThemeCount).toBe(1);
+});
+
+test("Disable/enable themePalette property for custom theme variations in theme property grid", (): any => {
+  const creator: CreatorTester = new CreatorTester({ showThemeTab: true });
+  creator.JSON = { questions: [{ type: "text", name: "q1" }] };
+  const themePlugin: ThemeTabPlugin = <ThemeTabPlugin>creator.getPlugin("theme");
+  themePlugin.activate();
+  const themeBuilder = themePlugin.model as ThemeBuilder;
+  const themeEditorSurvey = themeBuilder.themeEditorSurvey;
+  const themeChooser = themeEditorSurvey.getQuestionByName("themeName") as QuestionDropdownModel;
+  const themeMode = themeEditorSurvey.getQuestionByName("themeMode") as QuestionButtonGroupModel;
+  const themePalette = themeEditorSurvey.getQuestionByName("themePalette") as QuestionButtonGroupModel;
+
+  expect(themeChooser.value).toBe("default");
+  expect(themeMode.value).toBe("panels");
+  expect(themeMode.isReadOnly).toBeFalsy();
+  expect(themePalette.value).toBe("light");
+  expect(themePalette.isReadOnly).toBeFalsy();
+
+  const fullThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: true, "colorPalette": "dark", cssVariables: {} });
+  expect(fullThemeName).toBe("custom-dark-panelless");
+  expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
+    "default",
+    "sharp",
+    "borderless",
+    "flat",
+    "plain",
+    "doubleborder",
+    "layered",
+    "solid",
+    "threedimensional",
+    "contrast",
+    "custom"
+  ]);
+
+  themeChooser.value = "custom";
+
+  expect(themeChooser.value).toBe("custom");
+  expect(themeMode.value).toBe("lightweight");
+  expect(themeMode.isReadOnly).toBeTruthy();
+  expect(themePalette.value).toBe("dark");
+  expect(themePalette.isReadOnly).toBeTruthy();
+
+  const fullLightThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: true, "colorPalette": "light", cssVariables: {} });
+  expect(fullLightThemeName).toBe("custom-light-panelless");
+  expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
+    "default",
+    "sharp",
+    "borderless",
+    "flat",
+    "plain",
+    "doubleborder",
+    "layered",
+    "solid",
+    "threedimensional",
+    "contrast",
+    "custom"
+  ]);
+
+  expect(themeChooser.value).toBe("custom");
+  expect(themeMode.value).toBe("lightweight");
+  expect(themeMode.isReadOnly).toBeTruthy();
+  expect(themePalette.value).toBe("dark");
+  expect(themePalette.isReadOnly).toBeFalsy();
+
+  themePlugin.removeTheme(fullThemeName);
+  themePlugin.removeTheme(fullLightThemeName);
+});
+
+test("Disable/enable themeMode property for custom theme variations in theme property grid", (): any => {
+  const creator: CreatorTester = new CreatorTester({ showThemeTab: true });
+  creator.JSON = { questions: [{ type: "text", name: "q1" }] };
+  const themePlugin: ThemeTabPlugin = <ThemeTabPlugin>creator.getPlugin("theme");
+  themePlugin.activate();
+  const themeBuilder = themePlugin.model as ThemeBuilder;
+  const themeEditorSurvey = themeBuilder.themeEditorSurvey;
+  const themeChooser = themeEditorSurvey.getQuestionByName("themeName") as QuestionDropdownModel;
+  const themeMode = themeEditorSurvey.getQuestionByName("themeMode") as QuestionButtonGroupModel;
+  const themePalette = themeEditorSurvey.getQuestionByName("themePalette") as QuestionButtonGroupModel;
+
+  expect(themeChooser.value).toBe("default");
+  expect(themeMode.value).toBe("panels");
+  expect(themeMode.isReadOnly).toBeFalsy();
+  expect(themePalette.value).toBe("light");
+  expect(themePalette.isReadOnly).toBeFalsy();
+
+  const fullThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: true, "colorPalette": "dark", cssVariables: {} });
+  expect(fullThemeName).toBe("custom-dark-panelless");
+  expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
+    "default",
+    "sharp",
+    "borderless",
+    "flat",
+    "plain",
+    "doubleborder",
+    "layered",
+    "solid",
+    "threedimensional",
+    "contrast",
+    "custom"
+  ]);
+
+  themeChooser.value = "custom";
+
+  expect(themeChooser.value).toBe("custom");
+  expect(themeMode.value).toBe("lightweight");
+  expect(themeMode.isReadOnly).toBeTruthy();
+  expect(themePalette.value).toBe("dark");
+  expect(themePalette.isReadOnly).toBeTruthy();
+
+  const fullPanellessThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: false, "colorPalette": "dark", cssVariables: {} });
+  expect(fullPanellessThemeName).toBe("custom-dark");
+  expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
+    "default",
+    "sharp",
+    "borderless",
+    "flat",
+    "plain",
+    "doubleborder",
+    "layered",
+    "solid",
+    "threedimensional",
+    "contrast",
+    "custom"
+  ]);
+
+  expect(themeChooser.value).toBe("custom");
+  expect(themeMode.value).toBe("lightweight");
+  expect(themeMode.isReadOnly).toBeFalsy();
+  expect(themePalette.value).toBe("dark");
+  expect(themePalette.isReadOnly).toBeTruthy();
+
+  themePlugin.removeTheme(fullThemeName);
+  themePlugin.removeTheme(fullPanellessThemeName);
 });

--- a/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
@@ -2533,6 +2533,7 @@ test("Disable/enable themeMode property for custom theme variations in theme pro
 
   const fullThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: true, "colorPalette": "dark", cssVariables: {} });
   expect(fullThemeName).toBe("custom-dark-panelless");
+  expect(Themes[fullThemeName]).toBeDefined();
   expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
     "default",
     "sharp",
@@ -2557,6 +2558,7 @@ test("Disable/enable themeMode property for custom theme variations in theme pro
 
   const fullPanellessThemeName = themePlugin.addTheme({ "themeName": "custom", isPanelless: false, "colorPalette": "dark", cssVariables: {} });
   expect(fullPanellessThemeName).toBe("custom-dark");
+  expect(Themes[fullPanellessThemeName]).toBeDefined();
   expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
     "default",
     "sharp",
@@ -2577,6 +2579,19 @@ test("Disable/enable themeMode property for custom theme variations in theme pro
   expect(themePalette.value).toBe("dark");
   expect(themePalette.isReadOnly).toBeTruthy();
 
-  themePlugin.removeTheme(fullThemeName);
-  themePlugin.removeTheme(fullPanellessThemeName);
+  themePlugin.removeTheme(fullThemeName, true);
+  expect(Themes[fullThemeName]).toBeUndefined();
+  expect(Themes[fullPanellessThemeName]).toBeUndefined();
+  expect(themeChooser.choices.map(c => c.value)).toStrictEqual([
+    "default",
+    "sharp",
+    "borderless",
+    "flat",
+    "plain",
+    "doubleborder",
+    "layered",
+    "solid",
+    "threedimensional",
+    "contrast"
+  ]);
 });


### PR DESCRIPTION
- Combine Survey and Theme Saving - Introduce an option to activate the Save button regardless of whether a survey layout or theme receives changes #4894
- Support custom themes variations (light/dark, panelless/panels)