### PR TITLE
Fixed #4897 - Warnings when scrolling a design surface in StrictMode - An attempt to set a property "errorText" of a disposed object "base"

### DIFF
--- a/packages/survey-creator-core/src/components/string-editor.ts
+++ b/packages/survey-creator-core/src/components/string-editor.ts
@@ -185,7 +185,7 @@ class StringItemsNavigatorMatrixDynamic extends StringItemsNavigatorMatrixDropdo
   }
 }
 
-export class StringEditorConnector extends Base {
+export class StringEditorConnector {
   public static get(locString: LocalizableString): StringEditorConnector {
     if (!locString["_stringEditorConnector"]) locString["_stringEditorConnector"] = new StringEditorConnector(locString);
     return locString["_stringEditorConnector"];
@@ -203,7 +203,6 @@ export class StringEditorConnector extends Base {
   public onEditComplete: EventBase<StringEditorViewModelBase, any> = new EventBase<StringEditorViewModelBase, any>();
   public onBackspaceEmptyString: EventBase<StringEditorViewModelBase, any> = new EventBase<StringEditorViewModelBase, any>();
   constructor(private locString: LocalizableString) {
-    super();
   }
 }
 export class StringEditorViewModelBase extends Base {
@@ -233,9 +232,15 @@ export class StringEditorViewModelBase extends Base {
     }
   }
 
+  public detachFromUI() {
+    this.connector?.onDoActivate.remove(this.activate);
+    this.getEditorElement = undefined;
+    this.blurEditor = undefined;
+  }
+
   public dispose(): void {
     super.dispose();
-    this.connector.onDoActivate.remove(this.activate);
+    this.detachFromUI();
   }
 
   public activate = () => {
@@ -249,7 +254,8 @@ export class StringEditorViewModelBase extends Base {
   }
 
   public setLocString(locString: LocalizableString) {
-    this.connector?.onDoActivate.clear();
+    this.connector?.onDoActivate.remove(this.activate);
+    this.locString = locString;
     this.connector = StringEditorConnector.get(locString);
     this.connector.onDoActivate.add(this.activate);
   }

--- a/packages/survey-creator-react/src/PageNavigator.tsx
+++ b/packages/survey-creator-react/src/PageNavigator.tsx
@@ -29,6 +29,9 @@ export class SurveyPageNavigator extends CreatorModelElement<
     this.containerRef = React.createRef();
   }
   protected createModel(): void {
+    if (this.model) {
+      this.model.dispose();
+    }
     this.model = new PageNavigatorViewModel(
       this.props.pagesController,
       this.props.pageEditMode
@@ -67,9 +70,9 @@ export class SurveyPageNavigator extends CreatorModelElement<
     const el = this.containerRef.current;
     if (!!el) {
       el.parentElement.parentElement.parentElement.onscroll = undefined;
-      this.model.stopItemsContainerHeightObserver();
     }
-    this.model.dispose();
+    this.model.stopItemsContainerHeightObserver();
+    this.model.setScrollableContainer(undefined);
   }
   renderElement(): JSX.Element {
     let className = "svc-page-navigator__selector";

--- a/packages/survey-creator-react/src/StringEditor.tsx
+++ b/packages/survey-creator-react/src/StringEditor.tsx
@@ -64,9 +64,7 @@ export class SurveyLocStringEditor extends CreatorModelElement<any, any> {
   }
   public componentWillUnmount() {
     super.componentWillUnmount();
-    this.baseModel.getEditorElement = undefined;
-    this.baseModel.blurEditor = undefined;
-    this.baseModel.dispose();
+    this.baseModel.detachFromUI();
     if (!this.locString) return;
     this.locString.onStringChanged.remove(this.onChangedHandler);
   }


### PR DESCRIPTION
Fixed #4897