### PR TITLE
Fixed #4881 - Setting an overriding property on the survey logo property doesn't disable the logo upload in the editor

### DIFF
--- a/packages/survey-creator-core/src/components/header/logo-image.ts
+++ b/packages/survey-creator-core/src/components/header/logo-image.ts
@@ -1,4 +1,4 @@
-import { Base, CssClassBuilder, property, SurveyModel } from "survey-core";
+import { Base, CssClassBuilder, property, Serializer, SurveyModel } from "survey-core";
 import { CreatorBase } from "../../creator-base";
 import { getAcceptedTypesByContentMode } from "../../utils/utils";
 require("./logo-image.scss");
@@ -8,7 +8,9 @@ export class LogoImageViewModel extends Base {
     super();
   }
   public get allowEdit() {
-    return !this.creator.readOnly;
+    const survey = this.creator.survey;
+    const property = Serializer.findProperty(survey.getType(), "logo");
+    return !this.creator.readOnly && (!property.overridingProperty || !survey[property.overridingProperty]);
   }
   public get containerCss() {
     return new CssClassBuilder()
@@ -28,9 +30,9 @@ export class LogoImageViewModel extends Base {
     });
   }
   public chooseFile(model: LogoImageViewModel) {
-    if(this.allowEdit) {
+    if (this.allowEdit) {
       const fileInput: HTMLInputElement =
-      <HTMLInputElement>model.root.getElementsByClassName("svc-choose-file-input")[0];
+        <HTMLInputElement>model.root.getElementsByClassName("svc-choose-file-input")[0];
       if (fileInput.files.length === 0) {
         model.creator.chooseFiles(fileInput, (files: File[]) => {
           model.uploadFile(model, fileInput, files);

--- a/packages/survey-creator-core/tests/tabs/designer.test.ts
+++ b/packages/survey-creator-core/tests/tabs/designer.test.ts
@@ -199,3 +199,30 @@ test("Property Grid and adding a validator in the code, Bug#4882", () => {
   q1.validators.push(new RegexValidator(""));
   expect(validatorsQuestion.visibleRows).toHaveLength(1);
 });
+test("overridingProperty affects LogoImageViewModel allowEdit", () => {
+  Serializer.addProperty("survey", {
+    name: "logoToggle:boolean",
+    category: "logo",
+    visibleIndex: 0
+  });
+  Serializer.findProperty("survey", "logo").overridingProperty = "logoToggle";
+  const creator = new CreatorTester();
+  creator.JSON = { elements: [{ type: "text", name: "q1" }] };
+  const logoEditor = new LogoImageViewModel(creator, null as any);
+
+  expect(creator.survey["logoToggle"]).toBeFalsy();
+  expect(logoEditor.allowEdit).toBeTruthy();
+
+  creator.survey["logoToggle"] = true;
+  expect(logoEditor.allowEdit).toBeFalsy();
+
+  Serializer.findProperty("survey", "logo").overridingProperty = "";
+
+  expect(creator.survey["logoToggle"]).toBeTruthy();
+  expect(logoEditor.allowEdit).toBeTruthy();
+
+  creator.readOnly = true;
+  expect(logoEditor.allowEdit).toBeFalsy();
+
+  Serializer.removeProperty("survey", "logoToggle");
+});


### PR DESCRIPTION
Fixed #4881