### PR TITLE
Fixed #4918 - Themes Tab - A survey logo appears incorrectly when the logo is defined in a custom locale

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/theme-builder.ts
+++ b/packages/survey-creator-core/src/components/tabs/theme-builder.ts
@@ -105,14 +105,6 @@ export class ThemeBuilder extends Base {
     return (_themeName || this.themeName) + "-" + this.themePalette;
   }
 
-  public get activeLanguage(): string {
-    return this.getPropertyValue("activeLanguage", this.survey.locale || surveyLocalization.defaultLocale);
-  }
-  public set activeLanguage(val: string) {
-    if (val === this.activeLanguage) return;
-    this.setPropertyValue("activeLanguage", val);
-    this.survey.locale = val;
-  }
   public get survey(): SurveyModel {
     return this.simulator.survey;
   }
@@ -232,6 +224,7 @@ export class ThemeBuilder extends Base {
       component: "svc-complete-page",
       data: this
     });
+    newSurvey.locale = json.locale;
     this.simulator.survey = newSurvey;
     this.updateSimulatorTheme();
     if (this.onSurveyCreatedCallback) this.onSurveyCreatedCallback(this.survey);
@@ -339,7 +332,6 @@ export class ThemeBuilder extends Base {
   public show() {
     this.showInvisibleElements = false;
     this.activePage = this.survey.activePage;
-    this.survey.locale = this.activeLanguage;
     this.isRunning = true;
   }
 

--- a/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/theme-builder.tests.ts
@@ -2596,3 +2596,34 @@ test("Disable/enable themeMode property for custom theme variations in theme pro
     "contrast"
   ]);
 });
+
+test("Simulator survey should respect survey current locale", (): any => {
+  const creator: CreatorTester = new CreatorTester({ showThemeTab: true });
+  creator.JSON = {
+    "locale": "fr",
+    "logo": {
+      "fr": "FR logo",
+    },
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          {
+            "type": "radiogroup",
+            "name": "question1",
+            "choices": [
+              "Item 1",
+              "Item 2",
+              "Item 3"
+            ]
+          }
+        ]
+      }
+    ]
+  };
+  const themePlugin: ThemeTabPlugin = <ThemeTabPlugin>creator.getPlugin("theme");
+  themePlugin.activate();
+  const themeBuilder = themePlugin.model as ThemeBuilder;
+  expect(themeBuilder.simulator.survey.locale).toBe(creator.survey.locale);
+  expect(themeBuilder.simulator.survey.locLogo.renderedHtml).toBe("FR logo");
+});


### PR DESCRIPTION
Fixed #4918