### PR TITLE
Fixed #4942 - We should handle upload status in upload processing - Image Uploads in Survey Creator - Introduce an API/option to display the previous image if the current image uploading failed (options.callback returns with the 'error' status)

### DIFF
--- a/packages/survey-creator-core/src/components/image-item-value.ts
+++ b/packages/survey-creator-core/src/components/image-item-value.ts
@@ -31,8 +31,10 @@ export class ImageItemValueWrapperViewModel extends ItemValueWrapperViewModel {
     const fileInput = <HTMLInputElement>model.itemsRoot.getElementsByClassName("svc-choose-file-input")[0];
     model.creator.chooseFiles(fileInput, (files: File[]) => {
       model.isUploading = true;
-      model.creator.uploadFiles(files, model.question, (_, link) => {
-        model.item.imageLink = link;
+      model.creator.uploadFiles(files, model.question, (status, link) => {
+        if (status === "success") {
+          model.item.imageLink = link;
+        }
         model.isUploading = false;
       });
     }, { element: model.question, item: model.item });
@@ -40,10 +42,12 @@ export class ImageItemValueWrapperViewModel extends ItemValueWrapperViewModel {
 
   public uploadFiles(files) {
     this.isUploading = true;
-    this.creator.uploadFiles(files, this.question, (_, link) => {
-      this.creator.createNewItemValue(this.question, this.isChoosingNewFile, (res: ItemValue): void => {
-        (<ImageItemValue>res).imageLink = link;
-      });
+    this.creator.uploadFiles(files, this.question, (status, link) => {
+      if (status === "success") {
+        this.creator.createNewItemValue(this.question, this.isChoosingNewFile, (res: ItemValue): void => {
+          (<ImageItemValue>res).imageLink = link;
+        });
+      }
       this.isChoosingNewFile = false;
       this.isUploading = false;
     });

--- a/packages/survey-creator-core/tests/components.tests.ts
+++ b/packages/survey-creator-core/tests/components.tests.ts
@@ -932,3 +932,29 @@ test("ImageItemValueWrapperViewModel pass context to onOpenFileChooser event", (
   expect(context.element).toBe(question);
   expect(context.item).toBe(question.choices[0]);
 });
+
+test("ImageItemValueWrapperViewModel shouldn't override existing image if upload fails", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [{ type: "imagepicker", name: "q1", choices: [1, 2, 3] }]
+  };
+  const question = <QuestionImagePickerModel>creator.survey.getAllQuestions()[0];
+  const rootElement = document.createElement("div");
+  rootElement.innerHTML = "<input type='file' class='svc-choose-file-input' />";
+  const imageItemAdorner = new ImageItemValueWrapperViewModel(creator, question, question.choices[0], undefined, rootElement);
+
+  const successFile = "image1.png";
+  const errorFile = "image2.png";
+  let isSuccess = true;
+  creator.onOpenFileChooser.add((s, o) => {
+    o.callback([{}]);
+  });
+  creator.onUploadFile.add((s, o) => {
+    o.callback(isSuccess ? "success" : "error", isSuccess ? successFile : errorFile);
+  });
+  imageItemAdorner.chooseFile(imageItemAdorner);
+  expect(question.choices[0].imageLink).toBe(successFile);
+  isSuccess = false;
+  imageItemAdorner.chooseFile(imageItemAdorner);
+  expect(question.choices[0].imageLink).toBe(successFile);
+});


### PR DESCRIPTION
Fixed #4942