### PR TITLE
Property Grid: Add headers to matrix tables (choices, columns, rows, …

### DIFF
--- a/packages/survey-creator-core/src/property-grid/matrices.ts
+++ b/packages/survey-creator-core/src/property-grid/matrices.ts
@@ -366,7 +366,6 @@ export abstract class PropertyGridEditorMatrix extends PropertyGridEditor {
       cellType: "text",
       rowCount: 0,
       columns: columns,
-      showHeader: columns.length > 2,
       hideColumnsIfEmpty: true,
       addRowText: this.getAddRowText(prop),
       keyDuplicationError: editorLocalization.getString(

--- a/packages/survey-creator-core/tests/property-grid/property-grid-v1.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid-v1.tests.ts
@@ -1577,14 +1577,14 @@ test("SurveyPropertyItemValuesEditor + koShowHeader", () => {
   var choicesQuestion = <QuestionMatrixDynamicModel>(
     propertyGrid.survey.getQuestionByName("choices")
   );
-  expect(choicesQuestion.showHeader).toBeFalsy(); //according to design header is not shown for item values editor
+  expect(choicesQuestion.showHeader).toBeTruthy();
 
   Serializer.findProperty("itemvalue", "text").visible = false;
   propertyGrid = new PropertyGridModelTester(question);
   choicesQuestion = <QuestionMatrixDynamicModel>(
     propertyGrid.survey.getQuestionByName("choices")
   );
-  expect(choicesQuestion.showHeader).toBeFalsy();
+  expect(choicesQuestion.showHeader).toBeTruthy();
   Serializer.findProperty("itemvalue", "text").visible = false;
 });
 test("SurveyPropertyCalculatedValueEditor", () => {

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -460,7 +460,7 @@ test("column[] property editor", (): any => {
     propertyGrid.survey.getQuestionByName("columns")
   );
   expect(columnsQuestion).toBeTruthy(); //"choices property editor created");
-  expect(columnsQuestion.showHeader).toBeFalsy; //"No header in matrix";
+  expect(columnsQuestion.showHeader).toBeTruthy();
   expect(columnsQuestion.getType()).toEqual("matrixdynamic"); //"It is a matrix";
   expect(columnsQuestion.columns).toHaveLength(2); //"There are two columns");
   expect(columnsQuestion.columns[0].title).toEqual("Name");


### PR DESCRIPTION
…etc.) fix #5154