### PR TITLE
#5285 The Not allowed to load local resource exception is thrown on an attempt to insert a script to a form's title

### DIFF
--- a/packages/survey-creator-core/src/components/string-editor.ts
+++ b/packages/survey-creator-core/src/components/string-editor.ts
@@ -464,7 +464,7 @@ export class StringEditorViewModelBase extends Base {
       // get text representation of clipboard
       var text = event.clipboardData.getData("text/plain");
       // insert text manually
-      document.execCommand("insertHTML", false, text);
+      document.execCommand("insertText", false, text);
     }
   }
   public onKeyDown(event: KeyboardEvent): boolean {


### PR DESCRIPTION
Fixes #5285

*Cannot be tested in testcafe or jest*

Issue refers to https://github.com/surveyjs/survey-creator/pull/4191