### PR TITLE
#5275 The `onItemValueAdded` event is not raised when a new matrix row is added by pressing the Enter key on the design surface

### DIFF
--- a/packages/survey-creator-core/src/components/string-editor.ts
+++ b/packages/survey-creator-core/src/components/string-editor.ts
@@ -161,13 +161,13 @@ class StringItemsNavigatorMatrix extends StringItemsNavigatorBase {
     if (items == this.question.columns) { titleBase = "Column "; propertyName = "columns"; }
     if (items == this.question.rows) { titleBase = "Row "; propertyName = "rows"; }
     const newItem = new ItemValue(getNextValue(titleBase, items.map(i => i.value)) as string);
+    items.push(text || newItem);
     creator.onItemValueAddedCallback(
       this.question,
       propertyName,
       newItem,
       items
     );
-    items.push(text || newItem);
   }
   protected getItemsPropertyName(items: any) {
     if (items == this.question.columns) return "columns";
@@ -182,8 +182,8 @@ class StringItemsNavigatorMatrixDropdown extends StringItemsNavigatorMatrix {
   protected addNewItem(creator: SurveyCreatorModel, items: any, text: string = null) {
     if (items == this.question.columns) {
       var column = new MatrixDropdownColumn(text || getNextValue("Column ", items.map(i => i.value)) as string);
-      creator.onMatrixDropdownColumnAddedCallback(this.question, column, this.question.columns);
       this.question.columns.push(column);
+      creator.onMatrixDropdownColumnAddedCallback(this.question, column, this.question.columns);
     }
     if (items == this.question.rows) super.addNewItem(creator, items, text);
   }

--- a/packages/survey-creator-core/src/creator-events-api.ts
+++ b/packages/survey-creator-core/src/creator-events-api.ts
@@ -276,7 +276,7 @@ export interface CollectionItemAddedEvent {
    */
   newItem: ItemValue;
   /**
-   * An array of collection items to which the target item belongs ([`columns`](https://surveyjs.io/form-library/documentation/api-reference/matrix-table-question-model#columns) or [`rows`](https://surveyjs.io/form-library/documentation/api-reference/matrix-table-question-model#rows) in matrix questions, [`choices`](https://surveyjs.io/form-library/documentation/api-reference/questionselectbase#choices) in select-based questions, etc.). This array does not include `options.newItem`.
+   * An array of collection items to which the target item belongs ([`columns`](https://surveyjs.io/form-library/documentation/api-reference/matrix-table-question-model#columns) or [`rows`](https://surveyjs.io/form-library/documentation/api-reference/matrix-table-question-model#rows) in matrix questions, [`choices`](https://surveyjs.io/form-library/documentation/api-reference/questionselectbase#choices) in select-based questions, etc.).
    */
   itemValues: ItemValue[];
 }
@@ -291,7 +291,7 @@ export interface MatrixColumnAddedEvent {
    */
   newColumn: MatrixDropdownColumn;
   /**
-   * An array of matrix columns. This array does not include `options.newColumn`.
+   * An array of matrix columns.
    */
   columns: MatrixDropdownColumn[];
 }

--- a/packages/survey-creator-core/tests/string-editor.tests.ts
+++ b/packages/survey-creator-core/tests/string-editor.tests.ts
@@ -731,7 +731,7 @@ test("StringEditorConnector for matrix - onItemValueAdded event", (): any => {
   var log = "";
 
   creator.onItemValueAdded.add((sender, options) => {
-    log += (options.obj as QuestionMatrixModel).name + ":" + options.itemValues.length + "+" + options.newItem.title;
+    log += (options.obj as QuestionMatrixModel).name + ":" + options.itemValues.map(c => c.title).join(",") + "+" + options.newItem.title;
   });
   creator.JSON = {
     elements: [
@@ -754,14 +754,14 @@ test("StringEditorConnector for matrix - onItemValueAdded event", (): any => {
   connectorItemC1.onEditComplete.fire(null, {});
   expect(log).toEqual("");
   connectorItemC2.onEditComplete.fire(null, {});
-  expect(log).toEqual("q1:2+Column 3");
+  expect(log).toEqual("q1:Column 1,Column 2,Column 3+Column 3");
 
   log = "";
 
   connectorItemR1.onEditComplete.fire(null, {});
   expect(log).toEqual("");
   connectorItemR2.onEditComplete.fire(null, {});
-  expect(log).toEqual("q1:2+Row 3");
+  expect(log).toEqual("q1:Row 1,Row 2,Row 3+Row 3");
 });
 
 test("StringEditorConnector for matrix - onMatrixColumnAdded event", (): any => {
@@ -770,7 +770,7 @@ test("StringEditorConnector for matrix - onMatrixColumnAdded event", (): any => 
   var log = "";
 
   creator.onMatrixColumnAdded.add((sender, options) => {
-    log += options.matrix.name + ":" + options.columns.length + "+" + options.newColumn.title;
+    log += options.matrix.name + ":" + options.columns.map(c => c.name).join(",") + "+" + options.newColumn.title;
   });
   creator.JSON = {
     elements: [
@@ -791,7 +791,7 @@ test("StringEditorConnector for matrix - onMatrixColumnAdded event", (): any => 
   connectorItemC1.onEditComplete.fire(null, {});
   expect(log).toEqual("");
   connectorItemC2.onEditComplete.fire(null, {});
-  expect(log).toEqual("q1:2+Column 3");
+  expect(log).toEqual("q1:Column 1,Column 2,Column 3+Column 3");
 });
 
 test("StringEditor on property value changing", () => {


### PR DESCRIPTION
Fixes #5275
Fixes #5274