### PR TITLE
Rating Scale - The Label Alignment option remains active even though Min and Max value labels are unspecified

### DIFF
--- a/packages/survey-creator-core/src/components/question-rating.ts
+++ b/packages/survey-creator-core/src/components/question-rating.ts
@@ -136,7 +136,7 @@ export class QuestionRatingAdornerViewModel extends Base {
   public get hasTopLabel(): boolean {
     return (this.element.rateDescriptionLocation == "top" ||
             this.element.rateDescriptionLocation == "topBottom") &&
-            !!this.element.rateMinDescription;
+            !!this.element.minRateDescription;
   }
   public get controlsClassNames(): string {
     return new CssClassBuilder()

--- a/packages/survey-creator-core/src/components/question-rating.ts
+++ b/packages/survey-creator-core/src/components/question-rating.ts
@@ -132,11 +132,17 @@ export class QuestionRatingAdornerViewModel extends Base {
       .append("svc-item-value-controls__button--disabled", !this.enableRemove)
       .append("svc-item-value-controls__remove").toString();
   }
+
+  public get hasTopLabel(): boolean {
+    return (this.element.rateDescriptionLocation == "top" ||
+            this.element.rateDescriptionLocation == "topBottom") &&
+            !!this.element.rateMinDescription;
+  }
   public get controlsClassNames(): string {
     return new CssClassBuilder()
       .append("svc-rating-question-controls")
       .append("svc-item-value-controls")
-      .append("svc-rating-question-controls--labels-top", this.element.rateDescriptionLocation == "top" || this.element.rateDescriptionLocation == "topBottom").toString();
+      .append("svc-rating-question-controls--labels-top", this.hasTopLabel).toString();
   }
   get addTooltip() {
     return getLocString("pe.addItem");

--- a/packages/survey-creator-core/tests/components.tests.ts
+++ b/packages/survey-creator-core/tests/components.tests.ts
@@ -600,6 +600,46 @@ test("QuestionRatingAdornerViewModel button styles", () => {
   expect(ratingAdorner.removeClassNames).toBe("svc-item-value-controls__button svc-item-value-controls__remove");
 });
 
+test("QuestionRatingAdornerViewModel controlsClassNames", () => {
+  const creator = new CreatorTester();
+  creator.maximumRateValues = 4;
+  creator.JSON = {
+    elements: [{ type: "rating", name: "q1", rateMax: 3 }]
+  };
+  const question = <QuestionRatingModel>creator.survey.getAllQuestions()[0];
+
+  const ratingAdorner = new QuestionRatingAdornerViewModel(
+    creator,
+    question,
+    <any>{}
+  );
+  expect(ratingAdorner.hasTopLabel).toBe(false);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
+  question.rateMinDescription = "min";
+  question.rateDescriptionLocation = "leftRight";
+  expect(ratingAdorner.hasTopLabel).toBe(false);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
+
+  question.rateMinDescription = "min";
+  question.rateDescriptionLocation = "top";
+  expect(ratingAdorner.hasTopLabel).toBe(true);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls svc-rating-question-controls--labels-top");
+
+  question.rateMinDescription = "min";
+  question.rateDescriptionLocation = "topBottom";
+  expect(ratingAdorner.hasTopLabel).toBe(true);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls svc-rating-question-controls--labels-top");
+
+  question.rateMinDescription = "";
+  question.rateDescriptionLocation = "top";
+  expect(ratingAdorner.hasTopLabel).toBe(false);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
+
+  question.rateMinDescription = "";
+  question.rateDescriptionLocation = "topBottom";
+  expect(ratingAdorner.hasTopLabel).toBe(false);
+  expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
+});
 test("QuestionRatingAdornerViewModel respect maximumRateValues with rate values", () => {
   const creator = new CreatorTester();
   creator.maximumRateValues = 4;

--- a/packages/survey-creator-core/tests/components.tests.ts
+++ b/packages/survey-creator-core/tests/components.tests.ts
@@ -615,27 +615,27 @@ test("QuestionRatingAdornerViewModel controlsClassNames", () => {
   );
   expect(ratingAdorner.hasTopLabel).toBe(false);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
-  question.rateMinDescription = "min";
+  question.minRateDescription = "min";
   question.rateDescriptionLocation = "leftRight";
   expect(ratingAdorner.hasTopLabel).toBe(false);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
 
-  question.rateMinDescription = "min";
+  question.minRateDescription = "min";
   question.rateDescriptionLocation = "top";
   expect(ratingAdorner.hasTopLabel).toBe(true);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls svc-rating-question-controls--labels-top");
 
-  question.rateMinDescription = "min";
+  question.minRateDescription = "min";
   question.rateDescriptionLocation = "topBottom";
   expect(ratingAdorner.hasTopLabel).toBe(true);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls svc-rating-question-controls--labels-top");
 
-  question.rateMinDescription = "";
+  question.minRateDescription = "";
   question.rateDescriptionLocation = "top";
   expect(ratingAdorner.hasTopLabel).toBe(false);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");
 
-  question.rateMinDescription = "";
+  question.minRateDescription = "";
   question.rateDescriptionLocation = "topBottom";
   expect(ratingAdorner.hasTopLabel).toBe(false);
   expect(ratingAdorner.controlsClassNames).toBe("svc-rating-question-controls svc-item-value-controls");


### PR DESCRIPTION
Fixes #5337