### PR TITLE
The 'Uncaught TypeError: e.useRateValues is not a function' exception…

### DIFF
--- a/packages/survey-creator-core/src/components/question-rating.ts
+++ b/packages/survey-creator-core/src/components/question-rating.ts
@@ -30,7 +30,8 @@ export class QuestionRatingAdornerViewModel extends Base {
   }
 
   static useRateValues(element: any): boolean {
-    return !!element.useRateValues && element.useRateValues();
+    const el = !!element.contentQuestion ? element.contentQuestion : element;
+    return !!el.useRateValues && el.useRateValues();
   }
 
   public addItem(model: QuestionRatingAdornerViewModel) {

--- a/packages/survey-creator-core/src/components/question-rating.ts
+++ b/packages/survey-creator-core/src/components/question-rating.ts
@@ -30,7 +30,7 @@ export class QuestionRatingAdornerViewModel extends Base {
   }
 
   static useRateValues(element: any): boolean {
-    return element.useRateValues();
+    return !!element.useRateValues && element.useRateValues();
   }
 
   public addItem(model: QuestionRatingAdornerViewModel) {

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -3267,3 +3267,20 @@ test("PropertyGridEditorMaskType editor: localize item", () => {
 
   enLocale.pe.maskTypes.none = oldMaskTypesNone;
 });
+test("PropertyGridEditorMaskType editor: localize item", () => {
+  ComponentCollection.Instance.add({
+    name: "CSAT",
+    inheritBaseProps: true,
+    questionJSON: {
+      type: "rating",
+      rateType: "labels"
+    }
+  });
+  const question = Serializer.createClass("CSAT", { name: "q1" });
+  expect(question.getType()).toBe("csat");
+  const propertyGrid = new PropertyGridModelTester(question);
+  const autoGenerateQuestion = propertyGrid.survey.getQuestionByName("autoGenerate");
+  expect(autoGenerateQuestion.value).toBeTruthy;
+
+  ComponentCollection.Instance.clear();
+});

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -3280,7 +3280,7 @@ test("PropertyGridEditorMaskType editor: localize item", () => {
   expect(question.getType()).toBe("csat");
   const propertyGrid = new PropertyGridModelTester(question);
   const autoGenerateQuestion = propertyGrid.survey.getQuestionByName("autoGenerate");
-  expect(autoGenerateQuestion.value).toBeTruthy;
+  expect(autoGenerateQuestion.value).toBeTruthy();
 
   ComponentCollection.Instance.clear();
 });


### PR DESCRIPTION
… is thrown when setting 'inheritBaseProps: true' for a Rating specialized question type fix #5370