### PR TITLE
chore(ci): add separate github action workflow that runs eslint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install modules
+        run: npm install
+      - name: Run ESLint
+        run: npm run lint


### PR DESCRIPTION
The current azure pipelines are very hard to read for developers not familiar with them.
Also they are very slow and do a lot.

This PR adds an extra workflow for PRs that just runs eslint via github actions. Note: since this is an open source repo the CI minutes for this are free afaik.

