### PR TITLE
Translation Tab - The All Strings / Used Strings Only dropdown items …

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
@@ -184,7 +184,7 @@ export class TabTranslationPlugin implements ICreatorPlugin {
       visible: false,
       mode: "small",
     }, {
-      items: [{ id: "show-all-strings", title: this.showAllStringsText }, { id: "show-used-strings-only", title: this.showUsedStringsOnlyText }],
+      items: [{ id: "show-all-strings", locTitleName: "ed.translationShowAllStrings" }, { id: "show-used-strings-only", locTitleName: "ed.translationShowUsedStringsOnly" }],
       allowSelection: true,
       onSelectionChanged: (item: IAction) => {
         this.model.showAllStrings = item.id === "show-all-strings";

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -2052,3 +2052,27 @@ test("Store locales order", () => {
   expect(visChoices2[2]).toEqual("es");
   expect(visChoices2[3]).toEqual("de");
 });
+test("Change test themes list actions titles on changing locale", (): any => {
+  const deutschStrings: any = {
+    ed: {
+      translationShowAllStrings: "Show All de",
+      translationShowUsedStringsOnly: "Used Strings Only de"
+    }
+  };
+  editorLocalization.locales["de"] = deutschStrings;
+  const creator = new CreatorTester({ showTranslationTab: true });
+  const dropdownAction = creator.getActionBarItem("svc-translation-show-all-strings");
+  expect(dropdownAction).toBeTruthy();
+  expect(dropdownAction.visible).toBeFalsy();
+  const listModel = <ListModel>dropdownAction.popupModel.contentComponentData.model;
+  const actions = listModel.actions;
+  expect(actions).toHaveLength(2);
+  expect(actions[0].title).toBe("All Strings");
+  expect(actions[1].title).toBe("Used Strings Only");
+  creator.locale = "de";
+  creator.activeTab = "translation";
+  expect(dropdownAction.visible).toBeTruthy();
+  expect(actions).toHaveLength(2);
+  expect(actions[0].title).toBe("Show All de");
+  expect(actions[1].title).toBe("Used Strings Only de");
+});


### PR DESCRIPTION
…appear untranslated when switching the UI locale at runtime fix #5490