### PR TITLE
After adding a new page using the Plus icon in the Page category of t…

### DIFF
--- a/packages/survey-creator-core/src/property-grid/matrices.ts
+++ b/packages/survey-creator-core/src/property-grid/matrices.ts
@@ -641,7 +641,7 @@ export class PropertyGridEditorMatrixPages extends PropertyGridEditorMatrix {
     return prop.type == "surveypages";
   }
   protected addItem(creator: ISurveyCreatorOptions, obj: Base, question: QuestionMatrixDynamicModel) {
-    (creator as CreatorBase).addPage();
+    (creator as CreatorBase).addPage(undefined, false);
   }
   protected getColumnClassName(obj: Base, prop: JsonObjectProperty): string {
     return "page@" + obj.getType();

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -3028,6 +3028,17 @@ test("Allow delete all pages by default", () => {
   expect(pagesQuestion.canRemoveRow(pagesQuestion.visibleRows[0])).toBeTruthy();
   expect(pagesQuestion.canRemoveRow(pagesQuestion.visibleRows[1])).toBeTruthy();
 });
+test("Do not select page on adding new page in the property grid #5564", () => {
+  const creator = new CreatorTester();
+  creator.JSON = { elements: [{ type: "text", name: "q1" }] };
+  expect(creator.survey.pages).toHaveLength(1);
+  creator.selectElement(creator.survey);
+  const pagesQuestion = <QuestionMatrixDynamicModel>creator.propertyGrid.getQuestionByName("pages");
+  const actions = pagesQuestion.getTitleActions();
+  actions[actions.length - 1].action();
+  expect(creator.survey.pages).toHaveLength(2);
+  expect((<any>creator.selectedElement).pages).toHaveLength(2);
+});
 test("Setup correct categories for dynamic properties in components", () => {
   ComponentCollection.Instance.add({
     name: "customdropdown",


### PR DESCRIPTION
…he Survey-level settings, the Property Grid then displays the settings of the newly added page. fix #5564