### PR TITLE
The Uncaught TypeError: Cannot read properties of null (reading 'isDi…

### DIFF
--- a/packages/survey-creator-core/src/plugins/undo-redo/undo-redo-manager.ts
+++ b/packages/survey-creator-core/src/plugins/undo-redo/undo-redo-manager.ts
@@ -300,7 +300,10 @@ export class UndoRedoArrayAction implements IUndoRedoAction {
   private getSenderElement(): Base {
     if(!this._sender.isDisposed || !this.survey) return this._sender;
     const name = this._sender["name"];
-    if(this._sender["isPage"] === true) return this.survey.getPageByName(name);
+    if(this._sender["isPage"] === true) {
+      if(this.survey.pages.length === 0) return this.survey.addNewPage();
+      return this.survey.getPageByName(name);
+    }
     if(this._sender["isPanel"] === true) return this.survey.getPanelByName(name);
     if(this._sender["isQuestion"] === true) return this.survey.getQuestionByName(name);
     return this._sender;

--- a/packages/survey-creator-core/tests/creator-empty.tests.ts
+++ b/packages/survey-creator-core/tests/creator-empty.tests.ts
@@ -183,6 +183,24 @@ test("Undo deleting a question that has been just added, bug#4479", (): any => {
   expect(page.questions[0].name).toBe("question1");
   creatorSetting.defaultNewSurveyJSON = savedNewJSON;
 });
+test("Undo/Redo on empty survey, bug#5581", (): any => {
+  const savedNewJSON = creatorSetting.defaultNewSurveyJSON;
+  creatorSetting.defaultNewSurveyJSON = {};
+  const creator = new CreatorTester();
+  creator.JSON = {};
+  creator.clickToolboxItem({ type: "text" });
+  expect(creator.selectedElementName).toBe("question1");
+  let page = creator.survey.pages[0];
+  expect(page.questions).toHaveLength(1);
+  creator.undo();
+  expect(creator.survey.pages).toHaveLength(0);
+  creator.redo();
+  expect(creator.survey.pages).toHaveLength(1);
+  page = creator.survey.pages[0];
+  expect(page.questions).toHaveLength(1);
+  expect(page.questions[0].name).toBe("question1");
+  creatorSetting.defaultNewSurveyJSON = savedNewJSON;
+});
 test("Create last question, delete page and select survey in property grid", (): any => {
   const savedNewJSON = creatorSetting.defaultNewSurveyJSON;
   creatorSetting.defaultNewSurveyJSON = {};


### PR DESCRIPTION
…sposed') exception is thrown when adding a question from a toolbox and performing the Undo -> Redo -> Undo action fix #5581