### PR TITLE
fix Deprecation Warning Sass

### DIFF
--- a/packages/survey-creator-core/src/components/page.scss
+++ b/packages/survey-creator-core/src/components/page.scss
@@ -57,6 +57,7 @@ svc-page {
   overflow: visible;
   margin-left: calcSize(3);
   margin-right: calcSize(3);
+  gap: calcSize(2);
 
   .sv-action {
     flex: 1 1 0;
@@ -66,8 +67,6 @@ svc-page {
     flex-grow: 1;
     border: none;
   }
-
-  gap: calcSize(2);
 }
 
 .svc-page__add-new-question {

--- a/packages/survey-creator-core/src/components/question.scss
+++ b/packages/survey-creator-core/src/components/question.scss
@@ -119,14 +119,13 @@ svc-question {
 .svc-question__content-actions {
   position: absolute;
   opacity: 0;
+  bottom: calcSize(2);
+  inset-inline-start: calcSize(4); // left
+  inset-inline-end: calcSize(3.5); // right
 
   &:focus-within {
     opacity: 1;
   }
-
-  bottom: calcSize(2);
-  inset-inline-start: calcSize(4); // left
-  inset-inline-end: calcSize(3.5); // right
 
   .sv-action--convertTo {
     max-width: max-content;
@@ -137,10 +136,10 @@ svc-question {
     }
 
     .sv-action-bar-item__title {
-      @include textEllipsis;
-
       display: inline-block;
       justify-content: left;
+
+      @include textEllipsis;
 
       &::after {
         content: " ";
@@ -583,11 +582,11 @@ svc-question,
 }
 
 .svc-widget__content {
+  width: 100%;
+
   .sd-question__content {
     pointer-events: none;
   }
-
-  width: 100%;
 }
 
 .svc-question__content {
@@ -759,6 +758,10 @@ svc-question,
   cursor: pointer;
   margin-right: calcSize(1);
   outline: none;
+  top: calcSize(2);
+  margin: 0;
+  position: absolute;
+  right: 0;
 
   use {
     fill: $foreground-light;
@@ -771,11 +774,6 @@ svc-question,
   &:focus {
     background-color: $primary-light;
   }
-
-  top: calcSize(2);
-  margin: 0;
-  position: absolute;
-  right: 0;
 }
 
 .sv-list__container .sv-action-bar-item--secondary {
@@ -926,15 +924,16 @@ svc-question,
   right: 0;
   visibility: hidden;
   .sv-action-bar-item {
-    use {
-      fill: $foreground-dim-light;
-    }
     margin: 0;
     padding: calcSize(0.5);
     opacity: 0.5;
     height: 24px;
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       opacity: initial;
+    }
+    use {
+      fill: $foreground-dim-light;
     }
   }
 }

--- a/packages/survey-creator-core/src/components/row.scss
+++ b/packages/survey-creator-core/src/components/row.scss
@@ -31,14 +31,14 @@
 
 .sd-panel .svc-row .sd-row--multiple {
   padding: calcSize(0);
-  & > div {
-    padding: 0;
-  }
   box-shadow: none;
   border-radius: 0;
   padding: 2px; //need for the https://github.com/surveyjs/survey-creator/issues/3288
   margin: -2px; //need for the https://github.com/surveyjs/survey-creator/issues/3288
   width: 100%;
+  & > div {
+    padding: 0;
+  }
 }
 
 .svc-row.svc-row--ghost {

--- a/packages/survey-creator-core/src/components/string-editor.scss
+++ b/packages/survey-creator-core/src/components/string-editor.scss
@@ -8,12 +8,12 @@
 }
 
 .svc-string-editor {
+  position: static;
+
   [contenteditable="true"] {
     user-select: text;
     -webkit-user-select: text;
   }
-
-  position: static;
 
   .sv-string-editor {
     position: relative;

--- a/packages/survey-creator-core/src/components/toolbox/toolbox-tool.scss
+++ b/packages/survey-creator-core/src/components/toolbox/toolbox-tool.scss
@@ -23,15 +23,14 @@
   }
 }
 
-
 // is always visible
 .svc-toolbox__item-container {
   outline: none;
+  padding: calcSize(1) 0;
 
   .sv-svg-icon use {
     fill: $foreground-light;
   }
-  padding: calcSize(1) 0;
 }
 
 //is visible only on hover
@@ -212,13 +211,13 @@
 .svc-toolbox:not(.svc-toolbox--compact) {
   .svc-toolbox__tool--pressed {
     .svc-toolbox__item:not(.sv-dots) {
+      color: $foreground;
+      opacity: 0.5;
+
       .sv-svg-icon use {
         fill: $foreground;
         opacity: 0.5;
       }
-
-      color: $foreground;
-      opacity: 0.5;
     }
 
     .svc-toolbox__item.svc-toolbox__item-subtype {

--- a/packages/survey-creator-core/src/property-grid-theme/blocks/spg-question.scss
+++ b/packages/survey-creator-core/src/property-grid-theme/blocks/spg-question.scss
@@ -91,15 +91,14 @@
   box-sizing: border-box;
   max-width: 50%;
   flex: 1;
+  display: flex;
+  align-items: center;
 
   .spg-question__title {
     padding: calcSize(1) calcSize(2);
     border-right: 1px solid $border;
     display: inline-block;
   }
-
-  display: flex;
-  align-items: center;
 }
 
 .spg-question__content--left {
@@ -107,14 +106,13 @@
 
   .spg-input.spg-input.spg-input {
     background-color: transparent;
+    box-shadow: none;
+    border: none;
 
     &:focus,
     &:focus-within {
       box-shadow: none;
     }
-
-    box-shadow: none;
-    border: none;
   }
 }
 
@@ -144,7 +142,6 @@
   background-color: $red-light;
   border-radius: calcSize(0.5);
   line-height: calcSize(3);
-
 }
 
 .spg-question__erbox,

--- a/packages/survey-creator-core/src/property-grid-theme/blocks/spg-table.scss
+++ b/packages/survey-creator-core/src/property-grid-theme/blocks/spg-table.scss
@@ -22,11 +22,11 @@
 }
 
 .spg-table__cell--detail-panel {
+  background: $background-dim;
+
   .spg-panel__content {
     box-shadow: none;
   }
-
-  background: $background-dim;
 }
 
 .spg-table__cell:not(.spg-table__cell--detail-panel):not(.spg-table__cell--actions):first-of-type {

--- a/packages/survey-creator-core/src/property-grid-theme/blocks/spg-theme-builder.scss
+++ b/packages/survey-creator-core/src/property-grid-theme/blocks/spg-theme-builder.scss
@@ -61,11 +61,12 @@
 
     .spg-question__title {
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
       .sv-string-viewer {
           white-space: nowrap;
         }
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
   }
 

--- a/packages/survey-creator-core/src/utils/context-button.scss
+++ b/packages/survey-creator-core/src/utils/context-button.scss
@@ -13,10 +13,10 @@
   height: calcSize(6);
   cursor: pointer;
   padding: calcSize(1.5);
+  outline: none;
   use {
     fill: $foreground-light;
   }
-  outline: none;
 }
 .svc-context-button {
   &:hover,


### PR DESCRIPTION
Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule.