### PR TITLE
Fixed #5697 - Multi-Select Matrix - The Radiogroup column choices popup editor displays a gap on the right side

### DIFF
--- a/packages/survey-creator-core/src/components/matrix-cell.scss
+++ b/packages/survey-creator-core/src/components/matrix-cell.scss
@@ -70,7 +70,6 @@
 }
 
 .svc-question__content--in-popup {
-  width: calc(100% - 25 * #{$base-unit});
   min-width: calcSize(70);
   padding: calcSize(5);
 }


### PR DESCRIPTION
Fixed #5697