### PR TITLE
Fixed #5714 - Page Navigator is blinking when page names are long

### DIFF
--- a/packages/survey-creator-core/src/components/page-navigator/page-navigator-item.scss
+++ b/packages/survey-creator-core/src/components/page-navigator/page-navigator-item.scss
@@ -74,6 +74,7 @@ svc-page-navigator-item,
   animation: 0.5s ease-in;
   padding: 0;
   opacity: 0;
+  max-width: 0;
   z-index: 20;
   position: absolute;
   top: 0;


### PR DESCRIPTION
Fixed #5714