### PR TITLE
Bug: Serializer.addpropery, type: "dropdown" cuts the text before dot…

### DIFF
--- a/packages/survey-creator-core/src/editorLocalization.ts
+++ b/packages/survey-creator-core/src/editorLocalization.ts
@@ -291,7 +291,7 @@ export class EditorLocalization {
     return res;
   }
   private getValueInternal(value: any, prefix: string, locale: string = null): string {
-    if (value === "" || value === null || value === undefined) return "";
+    if (!value || value.indexOf(".") > -1) return "";
     value = value.toString();
     const res = this.getString(prefix + "." + value, locale);
     if (!!res) return res;

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -233,7 +233,7 @@ test("dropdown property editor, get choices on callback", () => {
   expect(callbackList[1]).toBeTruthy();
   Serializer.removeProperty("survey", "region");
 });
-test("Serializer.addpropery, type: 'dropdown' cuts the text before dots, provided into choices. Bug#5787", (): any => {
+test("Serializer.addpropery, type: 'dropdown' cuts the text before dots, provided into choices. Bug #5787", (): any => {
   Serializer.addProperty("survey", { name: "prop1:dropdown", type: "dropdown",
     choices: ["Gemini 1.5 Pro", "Claude 3.5 Sonnet"] });
   const survey = new SurveyModel();

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -233,6 +233,21 @@ test("dropdown property editor, get choices on callback", () => {
   expect(callbackList[1]).toBeTruthy();
   Serializer.removeProperty("survey", "region");
 });
+test("Serializer.addpropery, type: 'dropdown' cuts the text before dots, provided into choices. Bug#5787", (): any => {
+  Serializer.addProperty("survey", { name: "prop1:dropdown", type: "dropdown",
+    choices: ["Gemini 1.5 Pro", "Claude 3.5 Sonnet"] });
+  const survey = new SurveyModel();
+  const propertyGrid = new PropertyGridModelTester(survey);
+  const question = propertyGrid.survey.getQuestionByName("prop1");
+  expect(question.getType()).toBe("dropdown");
+  expect(question.choices).toHaveLength(2);
+  expect(question.choices[0].value).toBe("Gemini 1.5 Pro");
+  expect(question.choices[1].value).toBe("Claude 3.5 Sonnet");
+  expect(question.choices[0].text).toBe("Gemini 1.5 Pro");
+  expect(question.choices[1].text).toBe("Claude 3.5 Sonnet");
+
+  Serializer.removeProperty("survey", "prop1");
+});
 
 test("set property editor", () => {
   Serializer.addProperty("question", {

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -233,7 +233,7 @@ test("dropdown property editor, get choices on callback", () => {
   expect(callbackList[1]).toBeTruthy();
   Serializer.removeProperty("survey", "region");
 });
-test("Serializer.addpropery, type: 'dropdown' cuts the text before dots, provided into choices. Bug #5787", (): any => {
+test("Serializer.addpropery, type: 'dropdown' cuts the text before dots, provided into choices. Bug#5787", (): any => {
   Serializer.addProperty("survey", { name: "prop1:dropdown", type: "dropdown",
     choices: ["Gemini 1.5 Pro", "Claude 3.5 Sonnet"] });
   const survey = new SurveyModel();


### PR DESCRIPTION
…s, provided into choices. fix #5787