### PR TITLE
Fixed #5783 - Weird drag behaviour to empty survey in Safari - stop undo/redo transaction on banned drop

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -163,6 +163,7 @@
 		"linebreak-style": [
 			"off",
 			"windows"
-		]
+		],
+ 		"react/no-is-mounted": "off"
 	}
 }

--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -1925,6 +1925,9 @@ export class SurveyCreatorModel extends Base
         this.setModified({ type: "ADDED_FROM_TOOLBOX", question: options.draggedElement });
       }
     });
+    this.dragDropSurveyElements.onDragClear.add((sender, options) => {
+      this.stopUndoRedoTransaction();
+    });
   }
   private initDragDropChoices() {
     this.dragDropChoices = new DragDropChoices(null, this);

--- a/packages/survey-creator-core/tests/creator-undo-redo.tests.ts
+++ b/packages/survey-creator-core/tests/creator-undo-redo.tests.ts
@@ -333,6 +333,50 @@ test("undo/redo DnD ", (): any => {
   expect(creator.survey.pages[0].elements.map(e => e.name)).toEqual(["question1", "question2"]);
   expect(creator.survey.pages[0].rows.length).toEqual(1);
 });
+test("undo/redo DnD stops transaction onDragClear", (): any => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    "logoPosition": "right",
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          {
+            "type": "radiogroup",
+            "name": "question1",
+            "choices": [
+              "item1",
+              "item2",
+              "item3"
+            ]
+          },
+          {
+            "type": "radiogroup",
+            "name": "question2",
+            "startWithNewLine": false,
+            "choices": [
+              "item1",
+              "item2",
+              "item3"
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const q1 = creator.survey.pages[0].elements[0];
+  const q2 = creator.survey.pages[0].elements[1];
+  creator.dragDropSurveyElements.onDragStart.fire({ dropTarget: q2, draggedElement: q1 }, {});
+
+  expect(creator.undoRedoManager["transactionCounter"]).toEqual(1);
+  expect(creator.undoRedoManager["_preparingTransaction"]).toBeDefined();
+
+  creator.dragDropSurveyElements.onDragClear.fire({ dropTarget: q2, draggedElement: q1 }, {});
+
+  expect(creator.undoRedoManager["transactionCounter"]).toEqual(0);
+  expect(creator.undoRedoManager["_preparingTransaction"]).toBe(null);
+});
 test("Undo restore deleted page and question", (): any => {
   const creator = new CreatorTester();
   creator.JSON = {


### PR DESCRIPTION
Fixed #5783