### PR TITLE
PR: Survey Creator: Page adorners overlap the question box when settings.designMode.showEmptyTitles is disabled

### DIFF
--- a/packages/survey-creator-core/src/components/page.scss
+++ b/packages/survey-creator-core/src/components/page.scss
@@ -52,6 +52,12 @@ svc-page {
   }
 }
 
+.svc-page__content.svc-page__content--hidden-empty-titles {
+  .sd-page {
+    padding-top: calcSize(3)
+  }
+}
+
 .svc-page__content--dragged {
   opacity: 0.25;
 }
@@ -431,13 +437,13 @@ svc-page {
       pointer-events: none;
     }
 
-    .sv-list__item.sv-list__item--group-selected > .sv-list__item-body {
+    .sv-list__item.sv-list__item--selected.sv-list__item--group > .sv-list__item-body {
       @include ctrDefaultBoldFont;
       background-color: $primary;
       color: $primary-foreground;
     }
 
-    .sv-list__item.sv-list__item--group-selected > .sv-list__item-body use {
+    .sv-list__item.sv-list__item--selected.sv-list__item--group > .sv-list__item-body use {
       fill: $background;
     }
   }

--- a/packages/survey-creator-core/src/components/page.ts
+++ b/packages/survey-creator-core/src/components/page.ts
@@ -1,4 +1,4 @@
-import { Action, ActionContainer, classesToSelector, ComputedUpdater, DragOrClickHelper, DragTypeOverMeEnum, IAction, IElement, PageModel, property, QuestionRowModel, SurveyElement } from "survey-core";
+import { Action, ActionContainer, classesToSelector, ComputedUpdater, DragOrClickHelper, DragTypeOverMeEnum, IAction, IElement, PageModel, property, QuestionRowModel, SurveyElement, settings as SurveySettings } from "survey-core";
 import { SurveyCreatorModel } from "../creator-base";
 import { IPortableMouseEvent } from "../utils/events";
 import { SurveyElementAdornerBase } from "./action-container-view-model";
@@ -262,6 +262,9 @@ export class PageAdorner extends SurveyElementAdornerBase<PageModel> {
     }
     if (this.creator.isElementSelected(this.page)) {
       result += " svc-page__content--selected";
+    }
+    if (SurveySettings.designMode.showEmptyTitles === false) {
+      result += " svc-page__content--hidden-empty-titles";
     }
     return result.trim();
   }


### PR DESCRIPTION
work for the https://github.com/surveyjs/survey-creator/issues/6206