### PR TITLE
#6233 Expand/Collapse Questions - Double-clicking a title text within an inplace editor collapses or expands a question

### DIFF
--- a/functionalTests/designer/surface.ts
+++ b/functionalTests/designer/surface.ts
@@ -471,3 +471,101 @@ test("Diabled Textarea issue", async (t) => {
   await t.click(QuestionInput);
   await t.expect(QuestionContent.hasClass(questionContentClass + "--selected")).ok();
 });
+
+test("Question adorner double click", async (t) => {
+  const json = {
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          {
+            "type": "comment",
+            "name": "q"
+          }
+        ]
+      }
+    ]
+  };
+  await setJSON(json);
+  await ClientFunction(() => {
+    window["creator"].expandCollapseButtonVisibility = "always";
+  })();
+  function isCollapsed() {
+    return Selector(".svc-question__content").hasClass("svc-question__content--collapsed");
+  }
+  await t.doubleClick(Selector(".svc-question__content"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-required-action"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".sv-action-bar-item--collapse button"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-question__content .sv-string-editor"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-question__content"), { offsetX: 5, offsetY: -5 });
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".svc-question__content"), { offsetX: 5, offsetY: -5 });
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".sd-question__title"));
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".sd-question__title"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-question__drag-area"));
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".svc-question__drag-area"));
+  await t.expect(isCollapsed()).notOk();
+
+});
+
+test("Page adorner double click", async (t) => {
+  const json = {
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          {
+            "type": "comment",
+            "name": "q"
+          }
+        ]
+      }
+    ]
+  };
+  await setJSON(json);
+  await ClientFunction(() => {
+    window["creator"].expandCollapseButtonVisibility = "always";
+    window["creator"].allowDragPages = true;
+  })();
+  function isCollapsed() {
+    return Selector(".svc-page__content").hasClass("svc-page__content--collapsed");
+  }
+  await t.doubleClick(Selector(".svc-page__content"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".sv-action-bar-item--collapse button"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-page__content .sv-string-editor"));
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-page__content"), { offsetX: 5, offsetY: -5 });
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".svc-page__content"), { offsetX: 5, offsetY: -5 });
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".sd-body__page"), { offsetY: 5 });
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".sd-body__page"), { offsetY: 5 });
+  await t.expect(isCollapsed()).notOk();
+
+  await t.doubleClick(Selector(".svc-page__content > .svc-question__drag-area"));
+  await t.expect(isCollapsed()).ok();
+  await t.doubleClick(Selector(".svc-page__content > .svc-question__drag-area"));
+  await t.expect(isCollapsed()).notOk();
+
+});

--- a/packages/survey-creator-core/src/components/action-container-view-model.ts
+++ b/packages/survey-creator-core/src/components/action-container-view-model.ts
@@ -256,8 +256,13 @@ export class SurveyElementAdornerBase<T extends SurveyElement = SurveyElement> e
     }
   }
 
+  protected allowExpandCollapseByDblClick(element: any) {
+    return true;
+  }
   public dblclick(event) {
-    if (this.allowExpandCollapse) this.collapsed = !this.collapsed;
+    if (this.allowExpandCollapseByDblClick(event.target)) {
+      if (this.allowExpandCollapse) this.collapsed = !this.collapsed;
+    }
     event.stopPropagation();
   }
   private allowEditOption: boolean;

--- a/packages/survey-creator-core/src/components/page.ts
+++ b/packages/survey-creator-core/src/components/page.ts
@@ -179,6 +179,14 @@ export class PageAdorner extends SurveyElementAdornerBase<PageModel> {
     };
     return container;
   }
+
+  protected allowExpandCollapseByDblClick(element: any) {
+    return element.classList.contains("svc-page__content") ||
+      element.classList.contains("sd-page") ||
+      element.closest(".svc-question__drag-area") && !element.closest(".svc-page__content-actions") ||
+      (element.closest(".sd-page__title") || element.closest(".sd-page__description")) && !element.closest(".svc-string-editor");
+  }
+
   protected getExpandCollapseAction(): IAction {
     const action = super.getExpandCollapseAction();
     action.needSeparator = true;

--- a/packages/survey-creator-core/src/components/question.ts
+++ b/packages/survey-creator-core/src/components/question.ts
@@ -551,7 +551,11 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
     delete json.name;
     return json;
   }
-
+  protected allowExpandCollapseByDblClick(element: any) {
+    return element.classList.contains("svc-question__content") ||
+      element.closest(".svc-question__drag-area") && !element.closest(".svc-question__top-actions") ||
+      element.closest(".sd-element__header") && !element.closest(".svc-string-editor");
+  }
   protected updateQuestionTypeOrSubtypeListModel(listModel: ListModel, subtypeOnly: boolean) {
     const availableItems = this.getConvertToTypes();
     const defaultJsons = this.buildDefaultJsonMap(availableItems);


### PR DESCRIPTION
Fixes #6233