### PR TITLE
#6339 Rename paramaters in the `onBeforeUndo` and `onBeforeRedo` events

### DIFF
--- a/packages/survey-creator-core/src/creator-events-api.ts
+++ b/packages/survey-creator-core/src/creator-events-api.ts
@@ -918,14 +918,24 @@ export interface BeforeUndoEvent {
   /**
    * A Boolean value that you can set to `false` if you want to prevent the undo operation.
    */
-  canUndo: boolean;
+  allow: boolean;
+  /**
+   * Obsolete. Use `options.allow` instead.
+   * @deprecated
+   */
+  canUndo?: boolean;
 }
 
 export interface BeforeRedoEvent {
   /**
    * A Boolean value that you can set to `false` if you want to prevent the redo operation.
    */
-  canRedo: boolean;
+  allow: boolean;
+  /**
+   * Obsolete. Use `options.allow` instead.
+   * @deprecated
+   */
+  canRedo?: boolean;
 }
 
 export interface PageAddingEvent {

--- a/packages/survey-creator-core/src/plugins/undo-redo/undo-redo-controller.ts
+++ b/packages/survey-creator-core/src/plugins/undo-redo/undo-redo-controller.ts
@@ -130,7 +130,8 @@ export class UndoRedoController extends Base {
   public undo() {
     if (!this.undoRedoManager) return;
     this.undoRedoManager.suspend();
-    var options = { canUndo: this.undoRedoManager.canUndo() };
+    const canUndo = this.undoRedoManager.canUndo();
+    var options = { canUndo: canUndo, allow: canUndo };
     this.onBeforeUndo.fire(this.creator, options);
     this.creator.onBeforeUndo.fire(this.creator, options);
     if (options.canUndo) {
@@ -141,7 +142,8 @@ export class UndoRedoController extends Base {
   }
   public redo() {
     if (!this.undoRedoManager) return;
-    const options = { canRedo: this.undoRedoManager.canRedo() };
+    const canRedo = this.undoRedoManager.canRedo();
+    const options = { canRedo: canRedo, allow: canRedo };
     this.onBeforeRedo.fire(this.creator, options);
     this.creator.onBeforeRedo.fire(this.creator, options);
     if (options.canRedo) {


### PR DESCRIPTION
Fixes #6339