### PR TITLE
#6501 `creator.onQuestionAdded` - The creator.text contains a different layout depending on whether a question was added by being dragged from a toolbox or added by clicking a toolbox item

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -1702,6 +1702,9 @@ export class SurveyCreatorModel extends Base
       page = this.addNewPageIntoSurvey();
     } else {
       this.survey.addPage(page);
+      page.questions.forEach(question => {
+        this.doOnQuestionAdded(question, page);
+      });
     }
     if (changeSelection) {
       this.selectElement(page);
@@ -2324,6 +2327,7 @@ export class SurveyCreatorModel extends Base
   private doOnQuestionAdded(question: Question, parentPanel: any) {
     question.name = this.generateUniqueName(question, question.name);
     var page = this.getPageByElement(question);
+    if (!page) return;
     var options = { question: question, page: page, reason: this.addNewElementReason };
     this.addNewElementReason = undefined;
     this.onQuestionAdded.fire(this, options);

--- a/packages/survey-creator-core/tests/creator-empty.tests.ts
+++ b/packages/survey-creator-core/tests/creator-empty.tests.ts
@@ -1,10 +1,11 @@
-import { SurveyModel, settings as surveySettings, Serializer } from "survey-core";
+import { SurveyModel, settings as surveySettings, Serializer, QuestionTextModel } from "survey-core";
 import { TabDesignerPlugin } from "../src/components/tabs/designer-plugin";
 import { settings as creatorSetting, settings } from "../src/creator-settings";
 import { CreatorTester } from "./creator-tester";
 import { UndoRedoController } from "../src/plugins/undo-redo/undo-redo-controller";
 import { TabJsonEditorTextareaPlugin } from "../src/components/tabs/json-editor-textarea";
 import { TabTestPlugin } from "../src/components/tabs/test-plugin";
+import { TabDesignerViewModel } from "../src/components/tabs/designer";
 
 const multipageJSON = {
   pages: [
@@ -203,4 +204,27 @@ test("Create last question, delete page and select survey in property grid", ():
   expect(creator.selectedElement.getType()).toBe("survey");
   expect(creator.propertyGrid.editingObj.getType()).toBe("survey");
   creatorSetting.defaultNewSurveyJSON = savedNewJSON;
+});
+test("onQuestionAdded fires correctly when drag drop into new page", () => {
+  const creator = new CreatorTester();
+  let json = {};
+  let cnt = 0;
+
+  creator.onQuestionAdded.add((sender, options) => {
+    cnt++;
+    json = { ...creator.survey.toJSON() };
+  });
+  const newPage = (creator.getPlugin("designer").model as TabDesignerViewModel).newPage;
+  newPage.addElement(new QuestionTextModel("q1"));
+  expect(cnt).toBe(1);
+  expect(json).toStrictEqual({
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          { "name": "q1", "type": "text", },
+        ],
+      },
+    ],
+  });
 });


### PR DESCRIPTION
Fixes #6501