### PR TITLE
#6555 Empty page's placeholder doesn't collapse animated.

### DIFF
--- a/packages/survey-creator-core/src/components/page.ts
+++ b/packages/survey-creator-core/src/components/page.ts
@@ -345,7 +345,7 @@ export class PageAdorner extends SurveyElementAdornerBase<PageModel> {
 
   protected getInnerAnimatedElements() {
     const cssClasses = this.surveyElement.cssClasses;
-    if (cssClasses.pageRow) return [].slice.call(this.rootElement?.querySelectorAll(`:scope .svc-page__footer, :scope ${classesToSelector(this.surveyElement.cssRoot)} > .svc-row`));
+    if (cssClasses.pageRow) return [].slice.call(this.rootElement?.querySelectorAll(`:scope .svc-page__footer, :scope .svc-page__placeholder_frame, :scope ${classesToSelector(this.surveyElement.cssRoot)} > .svc-row`));
     return null;
   }
   public onPageSelected() { }


### PR DESCRIPTION
Fixes #6555
Fixed https://github.com/surveyjs/private-tasks/issues/452