### PR TITLE
SurveyLogic: Delete completedHtmlOnCondition item instead of removing…

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/logic-items.ts
+++ b/packages/survey-creator-core/src/components/tabs/logic-items.ts
@@ -44,15 +44,20 @@ export class SurveyLogicAction {
   public apply(expression: string, isRenaming: boolean = false): void {
     if (!!this.element && !!this.logicType) {
       this.element[this.logicType.propertyName] = expression;
-      if (
-        !expression &&
-        Serializer.isDescendantOf(this.element.getType(), "surveytrigger")
-      ) {
-        var index = this.survey.triggers.indexOf(<SurveyTrigger>this.element);
-        if (index > -1) {
-          this.survey.triggers.splice(index, 1);
+      if (!expression) {
+        if(Serializer.isDescendantOf(this.element.getType(), "surveytrigger")) {
+          this.removeElement(this.survey.triggers, this.element);
+        }
+        if(Serializer.isDescendantOf(this.element.getType(), "htmlconditionitem")) {
+          this.removeElement(this.survey.completedHtmlOnCondition, this.element);
         }
       }
+    }
+  }
+  private removeElement(items: Array<any>, element: any): void {
+    var index = items.indexOf(this.element);
+    if (index > -1) {
+      items.splice(index, 1);
     }
   }
   public renameQuestion(oldName: string, newName: string): void {

--- a/packages/survey-creator-core/tests/tabs/logic.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/logic.tests.ts
@@ -3628,3 +3628,19 @@ test("Limit the number of trigger types, #6031", () => {
 
   expect(logic.logicTypes.length > 4).toBeTruthy();
 });
+test("SurveyLogic: Delete completedHtmlOnCondition item instead of removing expression only, Bug#6657", () => {
+  var survey = new SurveyModel({
+    elements: [
+      { type: "text", name: "q1" },
+    ],
+    completedHtmlOnCondition: [
+      { expression: "{q1} = 4", html: "Custom html" },
+    ]
+  });
+  expect(survey.completedHtmlOnCondition).toHaveLength(1);
+  const logic = new SurveyLogicUI(survey);
+  expect(logic.items).toHaveLength(1);
+  logic.removeItem(logic.items[0]);
+  expect(survey.completedHtmlOnCondition).toHaveLength(0);
+});
+


### PR DESCRIPTION
… expression only, fix #6657