### PR TITLE
#6681 Toolbox subitems: A bottom subitem's shadow overflows the container

### DIFF
--- a/packages/survey-creator-core/src/components/toolbox/toolbox-tool.scss
+++ b/packages/survey-creator-core/src/components/toolbox/toolbox-tool.scss
@@ -318,6 +318,7 @@
   .sv-list__container {
     flex-wrap: wrap;
     column-gap: calcSize(2);
+    row-gap: var(--ctr-toolbox-group-gap, var(--sjs-spacing-x05));
   }
 
   .sv-popup__body-content {
@@ -343,6 +344,7 @@
     padding-bottom: var(--ctr-toolbox-submenu-group-margin-bottom-last, var(--sjs-spacing-x150));
     padding-inline-start: var(--ctr-toolbox-submenu-group-margin-left, var(--sjs-spacing-x150));
     overflow: visible;
+    box-sizing: border-box;
   }
 
   .sv-list__item:hover > .sv-list__item-body,
@@ -394,6 +396,10 @@
 
   .svc-toolbox__item-title {
     padding: 0;
+  }
+
+  .svc-toolbox__tool-content {
+    padding-block-start: 0;
   }
 }
 


### PR DESCRIPTION
Fixes #6681