### PR TITLE
A custom new page name localization string (ed.newPageName) is ignore…

### DIFF
--- a/packages/survey-creator-core/src/property-grid/matrices.ts
+++ b/packages/survey-creator-core/src/property-grid/matrices.ts
@@ -687,7 +687,7 @@ export class PropertyGridEditorMatrixPages extends PropertyGridEditorMatrix {
     return "name";
   }
   protected getBaseValue(prop: JsonObjectProperty): string {
-    return "page";
+    return editorLocalization.getString("ed.newPageName");
   }
   protected getAllowRowDragDrop(prop: JsonObjectProperty): boolean { return true; }
 }

--- a/packages/survey-creator-core/tests/creator-base-v1.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base-v1.tests.ts
@@ -936,8 +936,8 @@ test("creator.onAddPanel and undo-redo manager, Bug#972", () => {
 });
 
 test("SurveyPropertyConditionEditor, set correct locale into internal survey, Bug #953", () => {
-  editorLocalization.currentLocale = "de";
   const creator = new CreatorTester();
+  editorLocalization.currentLocale = "de";
   creator.JSON = {
     elements: [
       { name: "q1", type: "text" },
@@ -955,8 +955,8 @@ test("SurveyPropertyConditionEditor, set correct locale into internal survey, Bu
   editorLocalization.currentLocale = "";
 });
 test("creator.onSurveyInstanceCreated, can pass ConditionEditor as model", () => {
-  editorLocalization.currentLocale = "de";
   const creator = new CreatorTester();
+  editorLocalization.currentLocale = "de";
   creator.JSON = {
     elements: [
       { name: "q1", type: "text" },

--- a/packages/survey-creator-core/tests/creator-tester.ts
+++ b/packages/survey-creator-core/tests/creator-tester.ts
@@ -10,6 +10,8 @@ const dummyQuestion = new QuestionLinkValueModel("q1");
 export class CreatorTester extends SurveyCreatorModel {
   constructor(options: ICreatorOptions = {}, options2?: ICreatorOptions) {
     super(options, options2);
+    //Reset the locale to the default one from the previous tests
+    this.locale = "";
     this.autoSaveDelay = 0;
     this.onSurveyInstanceCreated.add((creator, options) => {
       options.survey.getRendererForString = (element: Base, name: string): any => {

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -3327,6 +3327,31 @@ test("check pages editor respects onPageAdding", () => {
   expect(creator.survey.pages.length).toBe(1);
   settings.defaultNewSurveyJSON = savedNewJSON;
 });
+test("Localication and survey.pages property, Bug#6687", () => {
+  const deutschStrings: any = {
+    ed: {
+      newPageName: "Seite"
+    }
+  };
+  editorLocalization.locales["de"] = deutschStrings;
+  const creator = new CreatorTester();
+  creator.locale = "de";
+  creator.JSON = {};
+  const propertyGrid = new PropertyGridModelTester(creator.survey);
+  const pagesQuestion = <QuestionMatrixDynamicModel>(
+    propertyGrid.survey.getQuestionByName("pages")
+  );
+  const propertyEditor = new PropertyGridEditorMatrixPages();
+  const options = { titleActions: [], question: pagesQuestion };
+  propertyEditor.onGetQuestionTitleActions(creator.survey, options, creator);
+  const addNewPageAction = options.titleActions[0] as IAction;
+
+  expect(creator.survey.pages.length).toBe(0);
+  addNewPageAction.action!();
+
+  expect(creator.survey.pages.length).toBe(1);
+  expect(creator.survey.pages[0].name).toBe("Seite1");
+});
 test("panellayoutcolumns doesn't have adding button", () => {
   const creator = new CreatorTester();
   creator.JSON = {

--- a/packages/survey-creator-core/tests/tabs/test.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/test.tests.ts
@@ -1075,8 +1075,8 @@ test("The Preview Survey button text is not translated Bug#6016", (): any => {
   expect(loc).toBeTruthy();
   if (!loc.ed) loc.ed = {};
   loc.ed.testSurveyAgain = deText;
-  editorLocalization.currentLocale = "en";
   const creator: CreatorTester = new CreatorTester();
+  editorLocalization.currentLocale = "en";
   expect(creator.locale).toBe("en");
   const testPlugin: TabTestPlugin = <TabTestPlugin>creator.getPlugin("test");
   expect(testPlugin.model).toBeFalsy();


### PR DESCRIPTION
…d when pages are added via a property grid collection editor fix #6687