### PR TITLE
fix: access global window safely

### DIFF
--- a/packages/survey-creator-js/src/index.ts
+++ b/packages/survey-creator-js/src/index.ts
@@ -2,19 +2,20 @@ import { preact } from "survey-js-ui";
 // eslint-disable-next-line surveyjs/no-imports-from-entries
 import { SurveyCreatorComponent, SurveyCreator } from "../../survey-creator-react/src/entries/index";
 
-const jQuery = window["jQuery"] || window["$"];
-
 export function renderSurveyCreator(creator: SurveyCreator, element: HTMLElement, props: any = {}) {
   const survey = preact.createElement(SurveyCreatorComponent, { creator, ...props });
   preact.render(survey, element);
 }
 
-if (!!jQuery) {
-  jQuery["fn"].extend({
-    SurveyCreator: function (props: any) {
-      return this.each(function () {
-        renderSurveyCreator(props.model, this, props);
-      } as any);
-    },
-  });
+if (typeof window !== "undefined") {
+  const jQuery = window["jQuery"] || window["$"];
+  if (!!jQuery) {
+    jQuery["fn"].extend({
+      SurveyCreator: function (props: any) {
+        return this.each(function () {
+          renderSurveyCreator(props.model, this, props);
+        } as any);
+      },
+    });
+  }
 }


### PR DESCRIPTION
During SSR the window object is not available.
While I realize this is probably not supported in the creator anyway, it is still good to check for the existence of `window` before accessing it.
Since it is only a very small change I think it can be part of the core.