### PR TITLE
Fix a11y title for svg icons within toolbox

### DIFF
--- a/packages/survey-creator-angular/src/toolbox/toolbox-item.component.html
+++ b/packages/survey-creator-angular/src/toolbox/toolbox-item.component.html
@@ -2,13 +2,13 @@
   <div role="button" [attr.aria-label]="this.item.tooltip" [class]="this.item.renderedCss"
     (click)="viewModel.click($event)" [key2click]>
     <span class="svc-toolbox__item-container">
-      <svg *ngIf="item.iconName" [iconName]="item.iconName" [size]="'auto'" class="svc-toolbox__item-icon" [title]="this.item.tooltip"
+      <svg *ngIf="item.iconName" [title]="item.tooltip || item.title" [iconName]="item.iconName" [size]="'auto'" class="svc-toolbox__item-icon"
         sv-ng-svg-icon></svg>
     </span>
     <span *ngIf="!isCompact" class="svc-toolbox__item-title">{{item.title}}</span>
     </div>
   <span *ngIf="isCompact" class="svc-toolbox__item-banner" (click)="viewModel.click($event)">
-    <svg *ngIf="item.iconName" [iconName]="item.iconName" [size]="'auto'" class="svc-toolbox__item-icon"
+    <svg *ngIf="item.iconName" [title]="item.tooltip || item.title" [iconName]="item.iconName" [size]="'auto'" class="svc-toolbox__item-icon"
       sv-ng-svg-icon></svg>
     <span>{{item.title}}</span>
     </span>

--- a/packages/survey-creator-knockout/src/toolbox/toolbox-item.html
+++ b/packages/survey-creator-knockout/src/toolbox/toolbox-item.html
@@ -2,7 +2,7 @@
   data-bind="attr: { role: 'button', 'aria-label': item.tooltip, title: item.tooltip }, css: item.renderedCss, click: (target, event)=>{ target.model.click(event); return true;}, key2click">
   <span class="svc-toolbox__item-container">
     <!-- ko if: iconName -->
-      <!-- ko component: { name: 'sv-svg-icon', params: { iconName: iconName, size: 'auto', css: 'svc-toolbox__item-icon' }  } -->
+      <!-- ko component: { name: 'sv-svg-icon', params: { iconName: iconName, size: 'auto', css: 'svc-toolbox__item-icon', title: tooltip || title }  } -->
       <!-- /ko -->
     <!-- /ko -->
   </span>
@@ -12,7 +12,7 @@
   </div>
 <!-- ko if: isCompact -->
 <span class="svc-toolbox__item-banner" data-bind="click: (target, event)=>{ target.model.click(event); return true;}">
-  <!-- ko component: { name: 'sv-svg-icon', params: { iconName: iconName, size: 'auto', css: "svc-toolbox__item-icon" }  } -->
+  <!-- ko component: { name: 'sv-svg-icon', params: { iconName: iconName, size: 'auto', css: "svc-toolbox__item-icon", title: tooltip || title }  } -->
   <!-- /ko -->
   <span data-bind="text: title"></span>
 </span>

--- a/packages/survey-creator-react/src/toolbox/ToolboxItem.tsx
+++ b/packages/survey-creator-react/src/toolbox/ToolboxItem.tsx
@@ -122,7 +122,7 @@ export class SurveyCreatorToolboxItem extends CreatorModelElement<
           event.persist();
           this.model.click(event);
         }}>
-        <SvgIcon size={"auto"} iconName={this.item.iconName} className="svc-toolbox__item-icon" title={this.item.tooltip}></SvgIcon>
+        <SvgIcon title={this.item.tooltip || this.item.title} size={"auto"} iconName={this.item.iconName} className="svc-toolbox__item-icon"></SvgIcon>
         <span>{this.item.title}</span>
       </span>
       :
@@ -140,7 +140,7 @@ export class SurveyCreatorToolboxItem extends CreatorModelElement<
         }}
       >
         <span className="svc-toolbox__item-container">
-          {!!this.item.iconName ? <SvgIcon size={"auto"} iconName={this.item.iconName} className="svc-toolbox__item-icon"></SvgIcon> : null}
+          {!!this.item.iconName ? <SvgIcon title={this.item.tooltip || this.item.title} size={"auto"} iconName={this.item.iconName} className="svc-toolbox__item-icon"></SvgIcon> : null}
         </span>
         {(this.props.isCompact ?
           null

--- a/packages/survey-creator-vue/src/toolbox/ToolboxItem.vue
+++ b/packages/survey-creator-vue/src/toolbox/ToolboxItem.vue
@@ -10,6 +10,7 @@
   >
     <span class="svc-toolbox__item-container">
       <SvComponent
+        :title="item.tooltip || item.title"
         :is="'sv-svg-icon'"
         v-if="item.iconName"
         :iconName="item.iconName"
@@ -23,6 +24,7 @@
   </div>
   <span v-if="isCompact" class="svc-toolbox__item-banner" @click="viewModel.click($event)">
       <SvComponent
+        :title="itemp.tooltip || item.title"
         :is="'sv-svg-icon'"
         :iconName="item.iconName"
         :size="24"


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2025-04-18 at 11 05 29" src="https://github.com/user-attachments/assets/f01ab653-07d4-47ef-bb39-4cb97ad371b6" />

Ensures there's always a `title` attribute for `svg` icons which are given the `img` `role`.

@dmitry-kurmanov @dk981234 