### PR TITLE
Add missing translation-related variables

### DIFF
--- a/packages/survey-creator-core/src/localization/english.ts
+++ b/packages/survey-creator-core/src/localization/english.ts
@@ -1796,6 +1796,7 @@ export var enStrings = {
     copyDisplayValue: "Copy display value", // Auto-generated string
     effectiveColSpan: "Column span",
     progressBarInheritWidthFrom: "Progress bar area width",
+    themeName: "Theme name",
   },
   theme: {
     advancedMode: "Advanced mode",


### PR DESCRIPTION
Added a variable for Theme name in the Survey Creator theme because there was no corresponding variable for it.