### PR TITLE
Fix `defaultLocale` docs

### DIFF
--- a/docs/survey-localization-translate-surveys-to-different-languages.md
+++ b/docs/survey-localization-translate-surveys-to-different-languages.md
@@ -98,7 +98,7 @@ creator.locale = "customlocale";
 If any translation strings are missing in your custom locale, they will be taken from the default English locale. You can specify the `defaultLocale` property to use another locale as default:
 
 ```js
-editorLocalization.defaultLocale = "fr";
+surveyLocalization.defaultLocale = "fr";
 ```
 
 ## Localize Survey Contents


### PR DESCRIPTION
`editorLocalization.defaultLocale = "fr"` does not do anything.

`surveyLocalization.defaultLocale = 'fr'` fixes it.