### PR TITLE
onElementAllowOperations - A question can still be removed regardless the `options.allowDelete = false` parameter

### DIFF
--- a/packages/survey-creator-core/src/creator-base.ts
+++ b/packages/survey-creator-core/src/creator-base.ts
@@ -3199,6 +3199,9 @@ export class SurveyCreatorModel extends Base
   }
   @undoRedoTransaction()
   protected deleteObject(obj: any) {
+    if (!obj || obj.isDisposed) return;
+    const allowedOperations = this.getElementAllowOperations(obj);
+    if (!allowedOperations.allowDelete) return;
     if (!this.checkOnElementDeleting(obj)) return;
     this.deleteObjectCore(obj);
   }

--- a/packages/survey-creator-core/tests/creator-base-v1.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base-v1.tests.ts
@@ -305,6 +305,39 @@ test("onElementDeleting event", () => {
   expect(counter).toEqual(3);
 });
 
+test("onElementAllowOperations event for deleteCurrentElement", () => {
+  const creator = new CreatorTester();
+  creator.JSON = { pages: [{ name: "page1" }] };
+  let counter = 0;
+  let canRemove = true;
+  creator.onElementAllowOperations.add((sender, options) => {
+    options.allowDelete = canRemove;
+    counter++;
+  });
+
+  const page = creator.survey.pages[0];
+  const q1 = page.addNewQuestion("text", "q1");
+  const q2 = page.addNewQuestion("text", "q2");
+  page.addNewQuestion("text", "q3");
+
+  expect(page.questions).toHaveLength(3);
+  creator.selectElement(creator.survey.getQuestionByName("q2"));
+  creator.deleteCurrentElement();
+  expect(page.questions).toHaveLength(2);
+  expect(counter).toEqual(1);
+
+  canRemove = false;
+  creator.selectElement(creator.survey.getQuestionByName("q1"));
+  creator.deleteCurrentElement();
+  expect(page.questions).toHaveLength(2);
+  expect(counter).toEqual(2);
+
+  canRemove = true;
+  creator.deleteCurrentElement();
+  expect(page.questions).toHaveLength(1);
+  expect(counter).toEqual(3);
+});
+
 test("Delete object and selectedElement property", () => {
   const creator = new CreatorTester();
   creator.JSON = {


### PR DESCRIPTION
Fixes #7064