### PR TITLE
#7088 `creator.onElementGetActions` - Actions appear misaligned when removing a Convert To Input Type action

### DIFF
--- a/packages/survey-creator-core/src/components/question.ts
+++ b/packages/survey-creator-core/src/components/question.ts
@@ -315,7 +315,13 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
     const actions = this.actionContainer.getVisibleActions();
     let switchToStartLocation = false;
     for (var i = actions.length - 1; i >= 0; i--) {
-      if (actions[i].id === "convertTo") switchToStartLocation = true;
+      if (actions[i].id === "convertTo" || actions[i].id === "convertInputType") {
+        actions[i].css = "svc-dropdown-action--convertTo";
+        if (!switchToStartLocation) {
+          actions[i].css += " svc-dropdown-action--convertTo-last";
+        }
+        switchToStartLocation = true;
+      }
       if (!actions[i].innerItem.location) actions[i].innerItem.location = switchToStartLocation ? "start" : "end";
     }
   }
@@ -488,7 +494,6 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
     newAction.disableHide = true;
     return newAction;
   }
-
   public static checkForNeedDefaultSubitems(items: QuestionToolboxItem[]) {
     items.filter(i => i.needDefaultSubitem === undefined).forEach((item: QuestionToolboxItem) => {
       item.needDefaultSubitem = false;
@@ -653,7 +658,6 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
   private createDropdownModel(options: { actionData: IAction, items: Array<IAction>, updateListModel: (listModel: ListModel) => void }): Action {
     const newAction = createDropdownActionModel({
       id: options.actionData.id,
-      css: "svc-dropdown-action--convertTo",
       iconName: options.actionData.iconName,
       iconSize: "auto",
       title: options.actionData.title,
@@ -739,7 +743,6 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
     if (!!inputTypeConverter) {
       items.push(inputTypeConverter);
     }
-    items[items.length - 1].css += " svc-dropdown-action--convertTo-last";
     if (typeof element["isRequired"] !== "undefined" && !!element.getType
       && SurveyHelper.isPropertyVisible(element, Serializer.findProperty(element.getType(), "isRequired"), this.creator)) {
       items.push(this.createRequiredAction());

--- a/packages/survey-creator-core/tests/creator-base-1.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base-1.tests.ts
@@ -2696,6 +2696,39 @@ test("convertInputType, hide it for readOnly creator", (): any => {
   questionModel = new QuestionAdornerViewModel(creator, creator.selectQuestionByName("q2"), undefined);
   expect(questionModel.getActionById("convertInputType").visible).toBeFalsy();
 });
+test("convertInputType styles with event", (): any => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      { type: "rating", name: "q1" },
+      { type: "text", name: "q2" },
+      { type: "boolean", name: "q3" },
+    ]
+  };
+
+  creator.onElementGetActions.add((sender, options) => {
+    if (options.element.getType() === "rating") {
+      const convertInputTypeActionIndex = options.actions.findIndex(
+        (x) => x.id === "convertInputType"
+      );
+      if (!!convertInputTypeActionIndex) {
+        options.actions.splice(convertInputTypeActionIndex, 1);
+      }
+    }
+  });
+
+  let questionModel = new QuestionAdornerViewModel(creator, creator.selectQuestionByName("q1"), undefined);
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo") > -1).toBeTruthy();
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo-last") > -1).toBeTruthy();
+  questionModel = new QuestionAdornerViewModel(creator, creator.selectQuestionByName("q2"), undefined);
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo") > -1).toBeTruthy();
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo-last") > -1).toBeFalsy();
+  expect(questionModel.getActionById("convertInputType").css.indexOf("svc-dropdown-action--convertTo") > -1).toBeTruthy();
+  expect(questionModel.getActionById("convertInputType").css.indexOf("svc-dropdown-action--convertTo-last") > -1).toBeTruthy();
+  questionModel = new QuestionAdornerViewModel(creator, creator.selectQuestionByName("q3"), undefined);
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo") > -1).toBeTruthy();
+  expect(questionModel.getActionById("convertTo").css.indexOf("svc-dropdown-action--convertTo-last") > -1).toBeTruthy();
+});
 test("convertInputType, check locale", (): any => {
   const creator = new CreatorTester();
   creator.JSON = {


### PR DESCRIPTION
Fixes #7088