### PR TITLE
#7128 Theme Editor - The Next/Previous buttons within the Property Grid Search bar do not navigate to settings located within the Advanced mode grid section when this section is disabled

### DIFF
--- a/packages/survey-creator-core/src/property-grid/search-manager.ts
+++ b/packages/survey-creator-core/src/property-grid/search-manager.ts
@@ -67,7 +67,7 @@ export class SearchManagerPropertyGrid extends SearchManager {
     const normalize = settings.comparator.normalizeTextCallback;
     let newValueInLow = normalize(newFilter, "search");
     newValueInLow = newValueInLow.toLocaleLowerCase().trim();
-    const visibleQuestions = this.survey.getAllQuestions().filter(q => q.isVisible);
+    const visibleQuestions = this.survey.getAllQuestions().filter(q => q.isVisibleInSurvey);
     return visibleQuestions.filter(q => {
       let srcString = q.name + "|" + q.title + "|" + q.description;
       if (!!srcString) {

--- a/packages/survey-creator-core/tests/property-grid/search-manager.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/search-manager.tests.ts
@@ -104,6 +104,58 @@ test("SearchManager: matchCounterText", () => {
   expect(searchManager.matchCounterText).toBe("3/3");
 });
 
+test("SearchManager: matchCounterText with visibility", () => {
+  const searchManager = new SearchManagerPropertyGrid();
+  const survey = new SurveyModel({
+    "elements": [
+      {
+        "type": "text",
+        "name": "q1",
+        "title": "First"
+      },
+      {
+        "type": "text",
+        "name": "q2",
+        "title": "Test",
+        "visible": "false",
+      },
+      {
+        "type": "text",
+        "name": "q3",
+        "title": "Last"
+      },
+      {
+        "type": "panel",
+        "name": "p1",
+        "visible": "false",
+        "elements": [
+          {
+            "type": "text",
+            "name": "q4",
+            "title": "Best"
+          },
+        ]
+      },
+    ]
+  });
+  searchManager.setSurvey(survey);
+  searchManager.filterString = "st";
+  searchManager.searchActionBar.flushUpdates();
+  const prevAction = searchManager.searchActionBar.visibleActions[0];
+  const nextAction = searchManager.searchActionBar.visibleActions[1];
+  expect(searchManager.searchActionBar.actions).toHaveLength(3);
+  expect(searchManager.searchActionBar.visibleActions).toHaveLength(3);
+  expect(prevAction.visible).toBeTruthy();
+  expect(nextAction.visible).toBeTruthy();
+  expect(searchManager.matchCounterText).toBe("1/2");
+
+  nextAction.action();
+  expect(searchManager.matchCounterText).toBe("2/2");
+
+  nextAction.action();
+  expect(searchManager.matchCounterText).toBe("1/2");
+});
+
 test("SearchManager: enabled searchActionBar items", () => {
   const searchManager = new SearchManagerPropertyGrid();
   const survey = createSurvey();


### PR DESCRIPTION
Fixes #7128