### PR TITLE
PR: CREATOR: Ability to set validations as warning only fix #9085

### DIFF
--- a/packages/survey-creator-core/src/localization/english.ts
+++ b/packages/survey-creator-core/src/localization/english.ts
@@ -694,7 +694,7 @@ export var enStrings = {
     maxCount: "Maximum count",
     regex: "Regular expression",
     surveyvalidator: {
-      text: "Error message",
+      text: "Validation message",
       expression: "Validation expression",
       notificationType: "Notification type"
     },
@@ -1488,7 +1488,8 @@ export var enStrings = {
       effectiveColSpan: "Specifies how many columns this question spans within the grid layout."
     },
     surveyvalidator: {
-      expression: "Use the magic wand icon to define when the question's value is considered valid."
+      expression: "Use the magic wand icon to define when the question's value is considered valid.",
+      notificationType: "Specifies the type of notification shown to users. Errors block progress until resolved. Warnings highlight issues but allow to continue. Infornational notes provide additional context or neutral guidance."
     },
     signaturepad: {
       signatureWidth: "Sets the width of the displayed signature area and the resulting image.",


### PR DESCRIPTION
work for the https://github.com/surveyjs/survey-library/issues/9085