### PR TITLE
now when logicAllowTextEditExpressions is false, using forceIsInputReadOnly instead onKeyDownPreprocess fix #7372

### DIFF
--- a/packages/survey-creator-core/src/property-grid/condition.ts
+++ b/packages/survey-creator-core/src/property-grid/condition.ts
@@ -127,12 +127,7 @@ export class PropertyGridEditorCondition extends PropertyGridEditorExpression {
   }
   public onSetup(obj: Base, question: Question, prop: JsonObjectProperty, options: ISurveyCreatorOptions) {
     if (options.logicAllowTextEditExpressions === false) {
-      question.onKeyDownPreprocess = (event: any) => {
-        const allowed = ["Tab", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"];
-        if (!event.ctrlKey && allowed.indexOf(event.key) < 0) {
-          event.preventDefault();
-        }
-      };
+      question.forceIsInputReadOnly = true;
     }
   }
   public createPropertyEditorSetup(

--- a/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/property-grid.tests.ts
@@ -659,8 +659,10 @@ test("Test options.logicAllowTextEditExpressions", () => {
   var propertyGrid = new PropertyGridModelTester(question, options);
   var conditionQuestion = <QuestionCommentModel>propertyGrid.survey.getQuestionByName("visibleIf");
   var expressionQuestion = <QuestionCommentModel>propertyGrid.survey.getQuestionByName("defaultValueExpression");
-  expect(conditionQuestion.onKeyDownPreprocess).toBeTruthy();
-  expect(expressionQuestion.onKeyDownPreprocess).toBeFalsy();
+  expect(conditionQuestion.forceIsInputReadOnly).toBeTruthy();
+  expect(conditionQuestion.isInputReadOnly).toBeTruthy();
+  expect(expressionQuestion.forceIsInputReadOnly).toBeFalsy();
+  expect(expressionQuestion.isInputReadOnly).toBeFalsy();
   expect(conditionQuestion.getTitleToolbar()).toBeTruthy();
   expect(conditionQuestion.titleActions).toHaveLength(2);
   expect(conditionQuestion.titleActions[1].enabled).toBeTruthy();
@@ -669,8 +671,10 @@ test("Test options.logicAllowTextEditExpressions", () => {
   propertyGrid = new PropertyGridModelTester(question, options);
   conditionQuestion = <QuestionCommentModel>propertyGrid.survey.getQuestionByName("visibleIf");
   expressionQuestion = <QuestionCommentModel>propertyGrid.survey.getQuestionByName("defaultValueExpression");
-  expect(conditionQuestion.onKeyDownPreprocess).toBeFalsy();
-  expect(expressionQuestion.onKeyDownPreprocess).toBeFalsy();
+  expect(conditionQuestion.forceIsInputReadOnly).toBeFalsy();
+  expect(conditionQuestion.isInputReadOnly).toBeFalsy();
+  expect(expressionQuestion.forceIsInputReadOnly).toBeFalsy();
+  expect(expressionQuestion.isInputReadOnly).toBeFalsy();
   expect(conditionQuestion.getTitleToolbar()).toBeTruthy();
   expect(conditionQuestion.titleActions).toHaveLength(3);
   expect(conditionQuestion.titleActions[1].enabled).toBeTruthy();


### PR DESCRIPTION
fix #7372