### PR TITLE
"Logical rules are incomplete" popup uses the default browser font style

### DIFF
--- a/packages/survey-creator-core/src/components/popup.scss
+++ b/packages/survey-creator-core/src/components/popup.scss
@@ -126,6 +126,10 @@
     color: var(--ctr-popup-title-color, var(--sjs-layer-1-foreground-100, #000000e6));
   }
 
+  .sv-popup__content {
+    @include ctrDefaultFont;
+  }
+
   &.sv-popup--menu-popup {
     .sv-popup-inner > .sv-popup__container,
     & > .sv-popup__container {


### PR DESCRIPTION
Fixes #7373