### PR TITLE
Dynamic Panel - A field's validation rule is not updated and works unexpectedly after a Dynamic Panel is copied fix #7457

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/logic.ts
+++ b/packages/survey-creator-core/src/components/tabs/logic.ts
@@ -373,7 +373,7 @@ export class SurveyLogic extends Base implements ISurveyLogicItemOwner {
   }
   private getValidators(): Array<Base> {
     var res = [];
-    var questions = this.survey.getAllQuestions();
+    var questions = this.survey.getAllQuestions(false, true);
     for (var i = 0; i < questions.length; i++) {
       this.AddElements((<Question>questions[i]).validators, res);
     }
@@ -381,7 +381,7 @@ export class SurveyLogic extends Base implements ISurveyLogicItemOwner {
   }
   private getItemValues(): Array<Base> {
     var res = [];
-    var questions = this.survey.getAllQuestions();
+    var questions = this.survey.getAllQuestions(false, true);
     for (var i = 0; i < questions.length; i++) {
       var q = questions[i];
       ["choices", "columns", "rows"].forEach(propName => this.addItemValuesCore(q, propName, res));

--- a/packages/survey-creator-core/tests/creator-base-v1.tests.ts
+++ b/packages/survey-creator-core/tests/creator-base-v1.tests.ts
@@ -1100,6 +1100,36 @@ test("Update expressions on copyElements for panel dynamic", () => {
   expect(newPanel.templateElements[1].name).toBe("question6");
   expect((<Question>newPanel.templateElements[1]).visibleIf).toEqual("{panel.question5} = 'a'");
 });
+test("Dynamic Panel - A field's validation rule is not updated and works unexpectedly after a Dynamic Panel is copied #10941", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "paneldynamic",
+        name: "question1",
+        templateElements: [
+          {
+            type: "text",
+            name: "question2"
+          },
+          {
+            type: "text",
+            name: "question3",
+            validators: [
+              {
+                type: "expression",
+                expression: "{panel.question2} > 20 and {panel.question3} < 80"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+  const panel = <QuestionPanelDynamicModel>creator.survey.getQuestionByName("question1");
+  const newPanel = <QuestionPanelDynamicModel>creator.copyElement(panel);
+  expect((<any>newPanel.templateElements[1]).validators[0].expression).toEqual("{panel.question5} > 20 and {panel.question6} < 80");
+});
 test("Update expressions on copyElements for matrix dynamic in detail panel", () => {
   const creator = new CreatorTester();
   creator.JSON = {


### PR DESCRIPTION
fix #10941