### PR TITLE
Caching errored expressions in property grid, fix #7495

### DIFF
--- a/packages/survey-creator-core/src/property-grid/index.ts
+++ b/packages/survey-creator-core/src/property-grid/index.ts
@@ -988,10 +988,10 @@ export class PropertyGridModel {
       }
     });
     this.survey.editingObj = this.obj;
-    this.applyErroredValuesToEditors();
     this.survey.getAllQuestions().forEach(q => {
       PropertyGridEditorCollection.onAfterSetValue(this.obj, q, q.property, this.options);
     });
+    this.applyErroredValuesToEditors();
     this.updateDependedPropertiesEditors();
 
     if (this.showOneCategoryInPropertyGrid) {

--- a/packages/survey-creator-core/tests/property-grid/condition-survey.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/condition-survey.tests.ts
@@ -2064,6 +2064,7 @@ test("Keep invalid visibleIf text after switching edited object, Issue#7495", ()
   expect(q1.visibleIf).toBeFalsy();
   expect(visibleIfQuestion.value).toBe(invalidExpression);
   expect(visibleIfQuestion.errors).toHaveLength(1);
+  expect(visibleIfQuestion.errors[0].text).toBe("Syntax error.");
 
   visibleIfQuestion.value = "{q2} = 1";
   expect(visibleIfQuestion.errors).toHaveLength(0);


### PR DESCRIPTION
fix #7495