### PR TITLE
UI Preset Editor - Property Grid Shows Expert Properties When Basic Preset Is Selected fix #7474

### DIFF
--- a/packages/survey-creator-core/src/ui-preset-editor/presets-editor.ts
+++ b/packages/survey-creator-core/src/ui-preset-editor/presets-editor.ts
@@ -77,6 +77,8 @@ export class CreatorPresetEditorModel extends Base implements ICreatorPresetEdit
   public set json(val: ICreatorPresetData) {
     this.preset.setJson(val);
     this.updateDataFromJson(this.modelValue);
+    this.applyFromSurveyModel(false);
+    this.activatePage(this.modelValue, this.creatorValue, this.modelValue.editablePresets);
     this.upldateResultJson();
   }
   public get jsonText(): string {

--- a/packages/survey-creator-core/tests-presets/presets-plugin.tests.ts
+++ b/packages/survey-creator-core/tests-presets/presets-plugin.tests.ts
@@ -1,6 +1,8 @@
 import { CreatorTester } from "../tests/creator-tester";
 import { UIPresetEditor } from "../src/ui-preset-editor/presets-plugin";
 import { CreatorPresets, ICreatorPresetConfig, PredefinedCreatorPresets, UIPreset } from "../src/ui-presets-creator/presets";
+import { Basic } from "../src/ui-presets/basic";
+import { Expert } from "../src/ui-presets/expert";
 
 const originalCreatorPresets: { [key: string]: ICreatorPresetConfig } = {};
 let originalPredefinedPresets: string[] = [];
@@ -91,5 +93,34 @@ describe("UIPresetEditor: saveClicked", () => {
     expect(performSaveSpy).toHaveBeenCalledTimes(1); // called
     plugin.deactivate();
   });
+});
+
+test("Selecting Basic preset should update property grid on Property Grid page", () => {
+  PredefinedCreatorPresets.push("expert", "basic");
+  CreatorPresets["expert"] = Expert;
+  CreatorPresets["basic"] = Basic;
+
+  const creator = new CreatorTester();
+  const plugin = new UIPresetEditor(creator);
+  plugin.activate();
+
+  const survey = plugin.model.model;
+  survey.currentPage = survey.getPageByName("page_propertyGrid");
+  survey.setValue("propertyGrid_selector", "survey");
+
+  const propGridCategories = survey.getQuestionByName("propertyGrid_categories");
+  const expertCategories = propGridCategories.value;
+  expect(expertCategories.length).toBeGreaterThan(1);
+
+  const presetsManager = (plugin as any)["presetsManager"];
+  presetsManager.selectPresetCallback(CreatorPresets["basic"]);
+
+  const basicCategories = propGridCategories.value;
+  expect(basicCategories).toHaveLength(1);
+  expect(basicCategories[0].properties.map((p: any) => p.name)).toEqual(
+    Basic.json.propertyGrid.definition.classes.survey.properties
+  );
+
+  plugin.deactivate();
 });
 


### PR DESCRIPTION
fix #7474