### PR TITLE
#7571 UI Preset Editor: Validate manually entered preset names against protected (registered) presets in Save As and Add New Preset dialogs

### DIFF
--- a/packages/survey-creator-core/src/ui-preset-editor/localization/english.ts
+++ b/packages/survey-creator-core/src/ui-preset-editor/localization/english.ts
@@ -193,6 +193,7 @@ export const enStrings = {
     completeText: "Save & Exit",
     pagePrevText: "Back",
     required: "Please enter a value.",
+    protectedPresetName: "This name is reserved for a built-in preset. Please choose a different name.",
   },
   plugin: {
     buttonTitle: "UI Preset Editor",

--- a/packages/survey-creator-core/src/ui-preset-editor/presets-manager.ts
+++ b/packages/survey-creator-core/src/ui-preset-editor/presets-manager.ts
@@ -84,6 +84,10 @@ export class PresetsManager {
 
     return [...defaultPresets, ...customPresets, editItem];
   }
+  private isProtectedPresetName(name: string): boolean {
+    return PredefinedCreatorPresets.indexOf(name) !== -1;
+  }
+
   private setPresetNewName(onSet: (newName: string) => void) {
     const survey = new SurveyModel({
       showNavigationButtons: "none",
@@ -103,6 +107,11 @@ export class PresetsManager {
     });
     survey.css = presetsCss;
     survey.questionErrorLocation = "bottom";
+    survey.onValidateQuestion.add((sender, options) => {
+      if (options.name === "presetName" && this.isProtectedPresetName(options.value)) {
+        options.error = getLocString("presets.editor.protectedPresetName");
+      }
+    });
 
     const popupModel = settings.showDialog?.(<IDialogOptions>{
       componentName: "survey",
@@ -302,6 +311,11 @@ export class PresetsManager {
           ...propertyGridCss.buttongroup,
         }
       };
+      addSurvey.onValidateQuestion.add((sender, options) => {
+        if (options.name === "presetName" && this.isProtectedPresetName(options.value)) {
+          options.error = getLocString("presets.editor.protectedPresetName");
+        }
+      });
       const popupModel = settings.showDialog?.(<IDialogOptions>{
         componentName: "survey",
         data: { survey: addSurvey, model: addSurvey },

--- a/packages/survey-creator-core/tests-presets/presets-manager.tests.ts
+++ b/packages/survey-creator-core/tests-presets/presets-manager.tests.ts
@@ -1068,6 +1068,86 @@ describe("PresetsManager", () => {
     });
   });
 
+  describe("Protected preset name validation", () => {
+    beforeEach(() => {
+      PredefinedCreatorPresets.push("basic", "advanced");
+      CreatorPresets["basic"] = { name: "basic", json: {}, visible: true };
+      CreatorPresets["advanced"] = { name: "advanced", json: {}, visible: true };
+    });
+
+    test("saveAs should reject a predefined preset name", () => {
+      let onApplyCallback: (() => boolean) | undefined;
+      mockShowDialog.mockImplementation((options) => {
+        onApplyCallback = options.onApply;
+        return { dispose: jest.fn() };
+      });
+
+      manager.saveAs({}, jest.fn());
+
+      const survey = mockShowDialog.mock.calls[0][0].data.survey as SurveyModel;
+      survey.setValue("presetName", "basic");
+
+      expect(onApplyCallback!()).toBe(false);
+    });
+
+    test("saveAs should allow a non-predefined name", () => {
+      let onApplyCallback: (() => boolean) | undefined;
+      mockShowDialog.mockImplementation((options) => {
+        onApplyCallback = options.onApply;
+        return { dispose: jest.fn() };
+      });
+
+      manager.saveAs({}, jest.fn());
+
+      const survey = mockShowDialog.mock.calls[0][0].data.survey as SurveyModel;
+      survey.setValue("presetName", "myCustomPreset");
+
+      expect(onApplyCallback!()).toBe(true);
+    });
+
+    test("addNewPreset dialog should reject a predefined preset name", () => {
+      const survey = new SurveyModel({ pages: [{ name: "page1", elements: [] }] });
+      manager.addPresetsListEditor(survey);
+      const matrixQuestion = survey.getQuestionByName("presetsList") as QuestionMatrixDynamicModel;
+
+      let onApplyCallback: (() => boolean) | undefined;
+      mockShowDialog.mockImplementation((options) => {
+        onApplyCallback = options.onApply;
+        return { dispose: jest.fn() };
+      });
+
+      survey.onMatrixRowAdding.fire(survey, { question: matrixQuestion, allow: true, canAddRow: true } as any);
+
+      const addSurvey = mockShowDialog.mock.calls[0][0].data.survey as SurveyModel;
+      addSurvey.setValue("presetName", "advanced");
+      addSurvey.setValue("template", "basic");
+
+      expect(onApplyCallback!()).toBe(false);
+      expect(CreatorPresets["advanced"].json).toEqual({});
+    });
+
+    test("addNewPreset dialog should allow a non-predefined name", () => {
+      const survey = new SurveyModel({ pages: [{ name: "page1", elements: [] }] });
+      manager.addPresetsListEditor(survey);
+      const matrixQuestion = survey.getQuestionByName("presetsList") as QuestionMatrixDynamicModel;
+
+      let onApplyCallback: (() => boolean) | undefined;
+      mockShowDialog.mockImplementation((options) => {
+        onApplyCallback = options.onApply;
+        return { dispose: jest.fn() };
+      });
+
+      survey.onMatrixRowAdding.fire(survey, { question: matrixQuestion, allow: true, canAddRow: true } as any);
+
+      const addSurvey = mockShowDialog.mock.calls[0][0].data.survey as SurveyModel;
+      addSurvey.setValue("presetName", "brandNewPreset");
+      addSurvey.setValue("template", "basic");
+
+      expect(onApplyCallback!()).toBe(true);
+      expect(CreatorPresets["brandNewPreset"]).toBeDefined();
+    });
+  });
+
   describe("Edge cases handling", () => {
     test("should handle empty presets list", () => {
       manager.update();


### PR DESCRIPTION
Fixes #7571