### PR TITLE
Fix: matrixdropdown cell editor duplicates inherited choices onto column (#7672)

### DIFF
--- a/packages/survey-creator-core/src/components/matrix-cell.ts
+++ b/packages/survey-creator-core/src/components/matrix-cell.ts
@@ -63,9 +63,7 @@ export class MatrixCellWrapperEditSurvey {
         questionJSON[key] = !columnJSON[key];
       }
     }
-    if (column.cellType === "default") {
-      column.cellType = qType;
-    }
+    const needsCellTypeChange = column.cellType === "default";
     let hasChanges = false;
     for (let key in questionJSON) {
       if (!Helpers.isTwoValueEquals(questionJSON[key], columnJSON[key])) {
@@ -95,6 +93,9 @@ export class MatrixCellWrapperEditSurvey {
       }
     }
     if (!hasChanges) return;
+    if (needsCellTypeChange) {
+      column.cellType = qType;
+    }
     matrix.onColumnCellTypeChanged(column);
     this.creator.setModified({ type: "MATRIX_CELL_EDITOR", column: column });
   }

--- a/packages/survey-creator-core/src/components/matrix-cell.ts
+++ b/packages/survey-creator-core/src/components/matrix-cell.ts
@@ -24,9 +24,11 @@ import "./matrix-cell.scss";
 export class MatrixCellWrapperEditSurvey {
   private surveyValue: SurveyModel;
   private creator: SurveyCreatorModel;
+  private originalCellQuestionJSON: any;
   constructor(creator: SurveyCreatorModel, private cellQuestion: Question, private column: MatrixDropdownColumn, model?: Base) {
     this.creator = creator;
     let questionJSON = cellQuestion.toJSON();
+    this.originalCellQuestionJSON = JSON.parse(JSON.stringify(questionJSON));
     questionJSON.type = cellQuestion.getType();
     this.surveyValue = creator.createSurvey({ elements: [questionJSON] }, "modal-question-editor", model, (survey: SurveyModel): void => {
       survey.css = defaultCss;
@@ -42,6 +44,9 @@ export class MatrixCellWrapperEditSurvey {
   }
   public get survey(): SurveyModel { return this.surveyValue; }
   public get question(): Question { return this.survey.getAllQuestions()[0]; }
+  private static extractItemValues(arr: Array<any>): Array<any> {
+    return arr.map(item => typeof item === "object" && item !== null ? item.value : item);
+  }
   public apply(): void {
     const matrix = <QuestionMatrixDropdownModelBase>this.cellQuestion.parentQuestion;
     const column: MatrixDropdownColumn = matrix.getColumnByName(this.cellQuestion.name);
@@ -61,11 +66,35 @@ export class MatrixCellWrapperEditSurvey {
     if (column.cellType === "default") {
       column.cellType = qType;
     }
+    let hasChanges = false;
     for (let key in questionJSON) {
       if (!Helpers.isTwoValueEquals(questionJSON[key], columnJSON[key])) {
-        column[key] = questionJSON[key];
+        // Skip properties that were not actually changed in the editor
+        if (Helpers.isTwoValueEquals(questionJSON[key], this.originalCellQuestionJSON[key])) continue;
+        hasChanges = true;
+        if (key in columnJSON) {
+          column[key] = questionJSON[key];
+        } else {
+          // The property was inherited from the matrix. If only item text/metadata
+          // changed (same item values), apply to the matrix to avoid duplicating
+          // the choices array onto the column. If the item values themselves differ,
+          // the user intends a column-specific override.
+          const origVal = this.originalCellQuestionJSON[key];
+          const newVal = questionJSON[key];
+          const matrixProp = Serializer.findProperty(matrix.getType(), key);
+          if (!!matrixProp && matrix[key] !== undefined &&
+              Array.isArray(origVal) && Array.isArray(newVal) &&
+              Helpers.isTwoValueEquals(
+                MatrixCellWrapperEditSurvey.extractItemValues(origVal),
+                MatrixCellWrapperEditSurvey.extractItemValues(newVal))) {
+            matrix[key] = newVal;
+          } else {
+            column[key] = questionJSON[key];
+          }
+        }
       }
     }
+    if (!hasChanges) return;
     matrix.onColumnCellTypeChanged(column);
     this.creator.setModified({ type: "MATRIX_CELL_EDITOR", column: column });
   }

--- a/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
+++ b/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
@@ -1,0 +1,168 @@
+import {
+  QuestionMatrixDropdownModel, QuestionMatrixDynamicModel,
+  ItemValue, QuestionDropdownModel, QuestionCheckboxModel
+} from "survey-core";
+import { CreatorTester } from "../creator-tester";
+import { MatrixCellWrapperEditSurvey } from "../../src/components/matrix-cell";
+
+// Reproduction tests for https://github.com/surveyjs/survey-creator/issues/7672
+// Multi-Select Matrix: Editing column choices via inline editor duplicates choices in JSON
+
+test("Bug #7672: Editing cell choice text when column has own choices should not duplicate", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "matrixdropdown",
+        name: "q1",
+        columns: [{ name: "col1", cellType: "dropdown", choices: [1, 2, 3] }],
+        rows: ["row1", "row2"]
+      }
+    ]
+  };
+
+  const matrix = <QuestionMatrixDropdownModel>creator.survey.getQuestionByName("q1");
+  const col = matrix.columns[0];
+  expect(col.choices).toHaveLength(3);
+
+  // Open cell editor
+  const cellQuestion = matrix.visibleRows[0].cells[0].question;
+  const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, col);
+  const editQuestion = <QuestionDropdownModel>editSurvey.question;
+
+  // Modify choice text (not value)
+  editQuestion.choices[0].text = "Modified One";
+  editSurvey.apply();
+
+  console.log("Column JSON after edit:", JSON.stringify(col.toJSON()));
+  console.log("Matrix JSON after edit:", JSON.stringify(matrix.toJSON()));
+  expect(col.choices).toHaveLength(3);
+  expect(col.choices[0].text).toBe("Modified One");
+});
+
+test("Bug #7672: Editing cell choice text when column inherits choices from matrix should not create column-level duplicates", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "matrixdropdown",
+        name: "q1",
+        columns: [{ name: "col1", cellType: "dropdown" }],
+        choices: [1, 2, 3, 4, 5],
+        rows: ["row1", "row2"]
+      }
+    ]
+  };
+
+  const matrix = <QuestionMatrixDropdownModel>creator.survey.getQuestionByName("q1");
+  const col = matrix.columns[0];
+
+  // Column should NOT have its own choices (inheriting from matrix)
+  const colJSON = col.toJSON();
+  console.log("Column JSON before edit:", JSON.stringify(colJSON));
+
+  // Open cell editor
+  const cellQuestion = matrix.visibleRows[0].cells[0].question;
+  const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, col);
+  const editQuestion = <QuestionDropdownModel>editSurvey.question;
+
+  // Show what the edit question looks like
+  console.log("Edit question choices:", JSON.stringify(editQuestion.toJSON().choices));
+
+  // Modify choice text (just adding text to an existing choice)
+  editQuestion.choices[0].text = "Strongly Disagree";
+  editSurvey.apply();
+
+  const matrixJSON = matrix.toJSON();
+  console.log("Matrix JSON after edit:", JSON.stringify(matrixJSON));
+  console.log("Column JSON after edit:", JSON.stringify(col.toJSON()));
+
+  // The matrix choices should still be 5
+  expect(matrix.choices).toHaveLength(5);
+
+  // Check for duplicated choices in JSON
+  const allChoices = [];
+  if (matrixJSON.choices) {
+    matrixJSON.choices.forEach((c: any) => {
+      allChoices.push(typeof c === "object" ? c.value : c);
+    });
+  }
+  if (matrixJSON.columns) {
+    matrixJSON.columns.forEach((col: any) => {
+      if (col.choices) {
+        col.choices.forEach((c: any) => {
+          allChoices.push(typeof c === "object" ? c.value : c);
+        });
+      }
+    });
+  }
+
+  // Check if any choice value appears in both matrix-level and column-level
+  const matrixChoiceValues = (matrixJSON.choices || []).map((c: any) => typeof c === "object" ? c.value : c);
+  const columnChoiceValues = [];
+  if (matrixJSON.columns) {
+    matrixJSON.columns.forEach((col: any) => {
+      if (col.choices) {
+        col.choices.forEach((c: any) => {
+          columnChoiceValues.push(typeof c === "object" ? c.value : c);
+        });
+      }
+    });
+  }
+  const duplicateValues = matrixChoiceValues.filter((v: any) => columnChoiceValues.includes(v));
+  console.log("Duplicate choice values (matrix + column):", duplicateValues);
+
+  // This is the key assertion - there should be no values duplicated between matrix and column
+  expect(duplicateValues).toHaveLength(0);
+});
+
+test("Bug #7672: Cell editor choices vs matrix-level choices interaction", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "matrixdropdown",
+        name: "q1",
+        columns: [
+          { name: "col1", cellType: "dropdown" },
+          { name: "col2", cellType: "dropdown" }
+        ],
+        choices: [
+          { value: 1, text: "Strongly Disagree" },
+          { value: 2, text: "Disagree" },
+          { value: 3, text: "Neutral" },
+          { value: 4, text: "Agree" },
+          { value: 5, text: "Strongly Agree" }
+        ],
+        rows: ["row1"]
+      }
+    ]
+  };
+
+  const matrix = <QuestionMatrixDropdownModel>creator.survey.getQuestionByName("q1");
+
+  // Open cell editor for col1
+  const cellQuestion = matrix.visibleRows[0].cells[0].question;
+  const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, matrix.columns[0]);
+  const editQuestion = <QuestionDropdownModel>editSurvey.question;
+
+  // Just change text of one choice
+  editQuestion.choices[2].text = "Neither Agree nor Disagree";
+  editSurvey.apply();
+
+  const matrixJSON = matrix.toJSON();
+  console.log("Full matrix JSON:", JSON.stringify(matrixJSON, null, 2));
+
+  // Count total choice entries in the JSON
+  let totalChoiceEntries = 0;
+  if (matrixJSON.choices) totalChoiceEntries += matrixJSON.choices.length;
+  if (matrixJSON.columns) {
+    matrixJSON.columns.forEach((col: any) => {
+      if (col.choices) totalChoiceEntries += col.choices.length;
+    });
+  }
+
+  // There should be at most 5 total choice entries (not 10)
+  console.log("Total choice entries in JSON:", totalChoiceEntries);
+  expect(totalChoiceEntries).toBeLessThanOrEqual(5);
+});

--- a/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
+++ b/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
@@ -1,6 +1,5 @@
 import {
-  QuestionMatrixDropdownModel, QuestionMatrixDynamicModel,
-  ItemValue, QuestionDropdownModel, QuestionCheckboxModel
+  QuestionMatrixDropdownModel, QuestionDropdownModel
 } from "survey-core";
 import { CreatorTester } from "../creator-tester";
 import { MatrixCellWrapperEditSurvey } from "../../src/components/matrix-cell";
@@ -34,8 +33,6 @@ test("Bug #7672: Editing cell choice text when column has own choices should not
   editQuestion.choices[0].text = "Modified One";
   editSurvey.apply();
 
-  console.log("Column JSON after edit:", JSON.stringify(col.toJSON()));
-  console.log("Matrix JSON after edit:", JSON.stringify(matrix.toJSON()));
   expect(col.choices).toHaveLength(3);
   expect(col.choices[0].text).toBe("Modified One");
 });
@@ -58,44 +55,21 @@ test("Bug #7672: Editing cell choice text when column inherits choices from matr
   const col = matrix.columns[0];
 
   // Column should NOT have its own choices (inheriting from matrix)
-  const colJSON = col.toJSON();
-  console.log("Column JSON before edit:", JSON.stringify(colJSON));
+  expect(col.toJSON()).not.toHaveProperty("choices");
 
   // Open cell editor
   const cellQuestion = matrix.visibleRows[0].cells[0].question;
   const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, col);
   const editQuestion = <QuestionDropdownModel>editSurvey.question;
 
-  // Show what the edit question looks like
-  console.log("Edit question choices:", JSON.stringify(editQuestion.toJSON().choices));
-
   // Modify choice text (just adding text to an existing choice)
   editQuestion.choices[0].text = "Strongly Disagree";
   editSurvey.apply();
 
   const matrixJSON = matrix.toJSON();
-  console.log("Matrix JSON after edit:", JSON.stringify(matrixJSON));
-  console.log("Column JSON after edit:", JSON.stringify(col.toJSON()));
 
   // The matrix choices should still be 5
   expect(matrix.choices).toHaveLength(5);
-
-  // Check for duplicated choices in JSON
-  const allChoices = [];
-  if (matrixJSON.choices) {
-    matrixJSON.choices.forEach((c: any) => {
-      allChoices.push(typeof c === "object" ? c.value : c);
-    });
-  }
-  if (matrixJSON.columns) {
-    matrixJSON.columns.forEach((col: any) => {
-      if (col.choices) {
-        col.choices.forEach((c: any) => {
-          allChoices.push(typeof c === "object" ? c.value : c);
-        });
-      }
-    });
-  }
 
   // Check if any choice value appears in both matrix-level and column-level
   const matrixChoiceValues = (matrixJSON.choices || []).map((c: any) => typeof c === "object" ? c.value : c);
@@ -110,9 +84,8 @@ test("Bug #7672: Editing cell choice text when column inherits choices from matr
     });
   }
   const duplicateValues = matrixChoiceValues.filter((v: any) => columnChoiceValues.includes(v));
-  console.log("Duplicate choice values (matrix + column):", duplicateValues);
 
-  // This is the key assertion - there should be no values duplicated between matrix and column
+  // There should be no values duplicated between matrix and column
   expect(duplicateValues).toHaveLength(0);
 });
 
@@ -151,7 +124,6 @@ test("Bug #7672: Cell editor choices vs matrix-level choices interaction", () =>
   editSurvey.apply();
 
   const matrixJSON = matrix.toJSON();
-  console.log("Full matrix JSON:", JSON.stringify(matrixJSON, null, 2));
 
   // Count total choice entries in the JSON
   let totalChoiceEntries = 0;
@@ -163,6 +135,5 @@ test("Bug #7672: Cell editor choices vs matrix-level choices interaction", () =>
   }
 
   // There should be at most 5 total choice entries (not 10)
-  console.log("Total choice entries in JSON:", totalChoiceEntries);
   expect(totalChoiceEntries).toBeLessThanOrEqual(5);
 });

--- a/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
+++ b/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
@@ -71,22 +71,11 @@ test("Bug #7672: Editing cell choice text when column inherits choices from matr
   // The matrix choices should still be 5
   expect(matrix.choices).toHaveLength(5);
 
-  // Check if any choice value appears in both matrix-level and column-level
-  const matrixChoiceValues = (matrixJSON.choices || []).map((c: any) => typeof c === "object" ? c.value : c);
-  const columnChoiceValues = [];
-  if (matrixJSON.columns) {
-    matrixJSON.columns.forEach((col: any) => {
-      if (col.choices) {
-        col.choices.forEach((c: any) => {
-          columnChoiceValues.push(typeof c === "object" ? c.value : c);
-        });
-      }
-    });
-  }
-  const duplicateValues = matrixChoiceValues.filter((v: any) => columnChoiceValues.includes(v));
+  // The column should still not have its own choices after a text-only edit
+  expect(col.toJSON()).not.toHaveProperty("choices");
 
-  // There should be no values duplicated between matrix and column
-  expect(duplicateValues).toHaveLength(0);
+  // The text change should have been applied to the matrix-level choices
+  expect(matrix.choices[0].text).toBe("Strongly Disagree");
 });
 
 test("Bug #7672: Cell editor choices vs matrix-level choices interaction", () => {
@@ -136,4 +125,72 @@ test("Bug #7672: Cell editor choices vs matrix-level choices interaction", () =>
 
   // There should be at most 5 total choice entries (not 10)
   expect(totalChoiceEntries).toBeLessThanOrEqual(5);
+
+  // The text change should have been applied at the matrix level
+  expect(matrix.choices[2].text).toBe("Neither Agree nor Disagree");
+});
+
+test("Bug #7672: Structural change to inherited choices creates column-level override", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "matrixdropdown",
+        name: "q1",
+        columns: [{ name: "col1", cellType: "dropdown" }],
+        choices: [1, 2, 3],
+        rows: ["row1"]
+      }
+    ]
+  };
+
+  const matrix = <QuestionMatrixDropdownModel>creator.survey.getQuestionByName("q1");
+  const col = matrix.columns[0];
+  expect(col.toJSON()).not.toHaveProperty("choices");
+
+  // Open cell editor and add a new choice (structural change)
+  const cellQuestion = matrix.visibleRows[0].cells[0].question;
+  const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, col);
+  const editQuestion = <QuestionDropdownModel>editSurvey.question;
+
+  editQuestion.choices = [1, 2, 3, 4];
+  editSurvey.apply();
+
+  // Structural change should create a column-level override
+  expect(col.choices).toHaveLength(4);
+  // Matrix-level choices should be unchanged
+  expect(matrix.choices).toHaveLength(3);
+});
+
+test("Bug #7672: Text edit on inherited choices propagates to all inheriting columns", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    elements: [
+      {
+        type: "matrixdropdown",
+        name: "q1",
+        columns: [
+          { name: "col1", cellType: "dropdown" },
+          { name: "col2", cellType: "dropdown" }
+        ],
+        choices: [1, 2, 3],
+        rows: ["row1"]
+      }
+    ]
+  };
+
+  const matrix = <QuestionMatrixDropdownModel>creator.survey.getQuestionByName("q1");
+
+  // Edit choice text via col1's cell editor
+  const cellQuestion = matrix.visibleRows[0].cells[0].question;
+  const editSurvey = new MatrixCellWrapperEditSurvey(creator, cellQuestion, matrix.columns[0]);
+  const editQuestion = <QuestionDropdownModel>editSurvey.question;
+
+  editQuestion.choices[0].text = "Updated Label";
+  editSurvey.apply();
+
+  // Change should be at the matrix level, visible to both columns
+  expect(matrix.choices[0].text).toBe("Updated Label");
+  expect(matrix.columns[0].toJSON()).not.toHaveProperty("choices");
+  expect(matrix.columns[1].toJSON()).not.toHaveProperty("choices");
 });

--- a/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
+++ b/packages/survey-creator-core/tests/property-grid/matrixdropdown-choices-bug.test.ts
@@ -66,8 +66,6 @@ test("Bug #7672: Editing cell choice text when column inherits choices from matr
   editQuestion.choices[0].text = "Strongly Disagree";
   editSurvey.apply();
 
-  const matrixJSON = matrix.toJSON();
-
   // The matrix choices should still be 5
   expect(matrix.choices).toHaveLength(5);
 


### PR DESCRIPTION
## Summary

Fixes #7672

When editing choices via the cell editor popup on a matrixdropdown column that inherits choices from the parent matrix, the `apply()` method in `MatrixCellWrapperEditSurvey` writes all inherited properties (including `choices`) to the column JSON. This duplicates the choices array — once at the matrix level and once at the column level — causing downstream data processing inconsistencies.

### Root cause

`apply()` compared the edited question JSON against the column JSON. For inherited properties (not present in the column JSON), any difference triggered a write to the column. Since inherited choices always differed from the empty column, they were always duplicated.

### Fix

- Track the original cell question JSON at editor open time
- Skip properties the user did not actually change
- For inherited array properties where only text/metadata changed (same item values), apply the change to the parent matrix instead of creating a column-level override
- If item values themselves differ (structural change), write to the column as before (intended override behavior)

## Test plan

- [x] Added 3 reproduction tests in `matrixdropdown-choices-bug.test.ts`
- [x] All 1744 existing tests pass
- [x] Verified: column with own choices still edits correctly
- [x] Verified: inherited choices text edits apply to matrix level (no duplication)
- [x] Verified: no-op edits do not trigger `setModified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)