### PR TITLE
Define a title for Logo Actions

### DIFF
--- a/packages/survey-creator-core/src/components/header/logo-image.ts
+++ b/packages/survey-creator-core/src/components/header/logo-image.ts
@@ -61,6 +61,7 @@ export class LogoImageViewModel extends Base {
       new Action({
         id: "add",
         iconName: "icon-choosefile",
+        title: this.creator.getLocString("ed.selectFile"),
         showTitle: false,
         appearance: { style: "brand" },
         action: () => {
@@ -70,6 +71,7 @@ export class LogoImageViewModel extends Base {
       new Action({
         id: "remove",
         iconName: "icon-clear",
+        title: this.creator.getLocString("ed.removeFile"),
         showTitle: false,
         appearance: { style: "alert" },
         action: () => {


### PR DESCRIPTION
This PR sets `ed.selectFile` / `ed.removeFile` as `title` Logo actions, matching the image picker pattern — icon-only UI, tooltip on hover, accessible name for screen readers.