### PR TITLE
Add overrides for rolldown package

### DIFF
--- a/packages/survey-creator-core/package.json
+++ b/packages/survey-creator-core/package.json
@@ -68,5 +68,8 @@
     "ts-node": "3.3.0",
     "tslib": "^2.8.1",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "rolldown": "1.0.3"
   }
 }


### PR DESCRIPTION
Add overrides for rolldown package version, to fix "SyntaxError: Invalid or unexpected token" in CI