### PR TITLE
fix: guard QuestionAdorner hover when surveyElement is undefined

### DIFF
--- a/packages/survey-creator-core/src/components/question.ts
+++ b/packages/survey-creator-core/src/components/question.ts
@@ -300,7 +300,7 @@ export class QuestionAdornerViewModel extends SurveyElementAdornerBase {
     return 0;
   }
   public hover(event: MouseEvent, element: HTMLElement | any) {
-    if (!this.surveyElement.isInteractiveDesignElement) {
+    if (!this.surveyElement || !this.surveyElement.isInteractiveDesignElement) {
       return;
     }
     super.hover(event, element);


### PR DESCRIPTION
## Why
`QuestionAdornerViewModel.hover` throws when React fires `onMouseLeave` after `detachFromUI` clears `surveyElement`.

## Summary
- Adds a null check before reading `isInteractiveDesignElement`
- Aligns with existing adorner null guards elsewhere in the same code path

Fixes #7888