### PR TITLE
fix: Translation tab Remove button / max selected locales (V1 backport)

### DIFF
--- a/packages/survey-creator-core/src/components/tabs/translation.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation.ts
@@ -861,17 +861,17 @@ export class Translation extends Base implements ITranslationLocales {
     }
     this.inputFileElement.click();
   }
-  private updateSettingsSurveyLocales() {
+  private updateSettingsSurveyLocales(prevVisibleLocales: Array<string>) {
     let [choices, locales] = this.getSurveyLocales();
-    const selectedLocales = [];
     if (!locales) locales = [];
-    for (var i = 0; i < locales.length; i++) {
-      if (!!this.localeInitialVisibleCallback && !this.localeInitialVisibleCallback(locales[i])) continue;
-      selectedLocales.push(locales[i]);
-    }
     const maxLocales = settings.translation.maximumSelectedLocales;
-    if (maxLocales > 0 && selectedLocales.length > maxLocales) {
-      selectedLocales.splice(maxLocales);
+    const selectedLocales = this.getSelectedLocales();
+    for (var i = 0; i < locales.length; i++) {
+      if (maxLocales > 0 && selectedLocales.length >= maxLocales) break;
+      const loc = locales[i];
+      if (selectedLocales.indexOf(loc) > -1 || prevVisibleLocales.indexOf(loc) > -1) continue;
+      if (!!this.localeInitialVisibleCallback && !this.localeInitialVisibleCallback(loc)) continue;
+      selectedLocales.push(loc);
     }
     this.setSelectedLocales(selectedLocales);
   }
@@ -1132,6 +1132,7 @@ export class Translation extends Base implements ITranslationLocales {
   }
   public reset(alwaysReset: boolean = true): void {
     if (!alwaysReset && !!this.root) return;
+    const prevVisibleLocales = this.getVisibleLocales();
     var rootObj = !!this.filteredPage ? this.filteredPage : this.survey;
     var rootName = !!this.filteredPage ? rootObj["name"] : "survey";
     this.root = new TranslationGroup(rootName, rootObj, this);
@@ -1139,7 +1140,7 @@ export class Translation extends Base implements ITranslationLocales {
     this.root.reset();
     this.resetLocales();
     this.isEmpty = !this.root.hasItems;
-    this.updateSettingsSurveyLocales();
+    this.updateSettingsSurveyLocales(prevVisibleLocales);
     this.updateLocales();
     this.resetStringsSurvey();
     this.updateChooseLanguageActions();
@@ -1191,6 +1192,9 @@ export class Translation extends Base implements ITranslationLocales {
   public resetLocales(): void {
     var locales = [""];
     this.root.fillLocales(locales);
+    this.getVisibleLocales().forEach(loc => {
+      if (locales.indexOf(loc) < 0) locales.push(loc);
+    });
     const sortedLocales = this.options.translationLocalesOrder;
     if (Array.isArray(sortedLocales) && sortedLocales.length > 0) {
       const sortFunc = (a: string, b: string, arr: Array<string>): number => {

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -2356,3 +2356,82 @@ test("Merge undo/redo into one transaction", () => {
   creator.undoRedoManager.undo();
   expect(creator.undoRedoManager.canUndo()).toBeFalsy();
 });
+
+test("Do not remove a just added locale on removing another locale, Bug#7904", () => {
+  const oldMaximumSelectedLocales = settings.translation.maximumSelectedLocales;
+  settings.translation.maximumSelectedLocales = 4;
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "text",
+        name: "question1",
+        title: {
+          default: "title en",
+          de: "title de",
+          fr: "title fr",
+          it: "title it",
+          es: "title es"
+        }
+      }
+    ]
+  });
+  const translation = new Translation(survey);
+  translation.reset();
+  const question = translation.localesQuestion;
+  expect(translation.getSelectedLocales()).toStrictEqual(["de", "fr", "it", "es"]);
+  translation.addLocale("pt");
+  expect(translation.getVisibleLocales()).toStrictEqual(["de", "fr", "it", "es", "pt"]);
+  // The maximum is reached, so the added "pt" locale is visible but not selected
+  expect(translation.getSelectedLocales()).toStrictEqual(["de", "fr", "it", "es"]);
+  // Remove the "de" locale to free a space for "pt"
+  question.removeRow(1, false);
+  // The added "pt" locale should stay in the languages list
+  expect(translation.getVisibleLocales()).toStrictEqual(["fr", "it", "es", "pt"]);
+  expect(translation.getSelectedLocales()).toStrictEqual(["fr", "it", "es"]);
+  // Select the "pt" locale, there is a space for it now
+  const ptRowIndex = question.value.map(v => v.name).indexOf("pt");
+  question.visibleRows[ptRowIndex].cells[0].question.value = true;
+  expect(translation.getSelectedLocales()).toStrictEqual(["fr", "it", "es", "pt"]);
+  expect([...translation.locales]).toStrictEqual(["", "fr", "it", "es", "pt"]);
+  settings.translation.maximumSelectedLocales = oldMaximumSelectedLocales;
+});
+
+test("Keep locales selection on removing a locale, Bug#7904", () => {
+  const oldMaximumSelectedLocales = settings.translation.maximumSelectedLocales;
+  settings.translation.maximumSelectedLocales = 4;
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "text",
+        name: "question1",
+        title: {
+          default: "title en",
+          de: "title de",
+          fr: "title fr",
+          it: "title it",
+          es: "title es",
+          pt: "title pt",
+          nl: "title nl"
+        }
+      }
+    ]
+  });
+  const translation = new Translation(survey);
+  translation.reset();
+  const question = translation.localesQuestion;
+  // The first maximumSelectedLocales locales are selected
+  expect(translation.getSelectedLocales()).toStrictEqual(["de", "fr", "it", "es"]);
+  expect(translation.getVisibleLocales()).toStrictEqual(["de", "fr", "it", "es", "pt", "nl"]);
+  // Unselect the "de" locale and select the "pt" locale, value rows are: ["", "de", "fr", "it", "es", "pt", "nl"]
+  question.visibleRows[1].cells[0].question.value = false;
+  question.visibleRows[5].cells[0].question.value = true;
+  expect(translation.getSelectedLocales()).toStrictEqual(["fr", "it", "es", "pt"]);
+  // Remove the "nl" locale
+  question.removeRow(6, false);
+  // V1 keeps all remaining locales; unselected ones follow selected (selected-first order)
+  expect(translation.getVisibleLocales()).toStrictEqual(["fr", "it", "es", "pt", "de"]);
+  // The selection should not be reset: "de" should stay unselected and "pt" should stay selected
+  expect(translation.getSelectedLocales()).toStrictEqual(["fr", "it", "es", "pt"]);
+  expect([...translation.locales]).toStrictEqual(["", "fr", "it", "es", "pt"]);
+  settings.translation.maximumSelectedLocales = oldMaximumSelectedLocales;
+});


### PR DESCRIPTION
- Backport of #7906 / bug/7904-translation-max-selected from master (v2.5.36) to V1