### PR TITLE
[library: 11659] fix: enhance expression validation for constants in library

### DIFF
--- a/packages/survey-creator-core/tests/property-grid/condition-survey.tests.ts
+++ b/packages/survey-creator-core/tests/property-grid/condition-survey.tests.ts
@@ -2355,7 +2355,7 @@ test("expression validation with multiple errors", () => {
       {
         "type": "text",
         "name": "q1",
-        "visibleIf": "{q2} = {q2} = {q3}",
+        "visibleIf": "{q11} = {q12} = {q13}",
         "requiredIf": "foo() = foo() = bar()",
         "enableIf": "foo({q2}) = foo({q2}) = bar({q2})",
       }
@@ -2369,7 +2369,7 @@ test("expression validation with multiple errors", () => {
 
   const visibleIfQuestion = propertyGrid.survey.getQuestionByName("visibleIf");
   expect(visibleIfQuestion.errors).toHaveLength(1);
-  expect(visibleIfQuestion.errors[0].text).toBe("Unknown variables: \"q2, q3\".");
+  expect(visibleIfQuestion.errors[0].text).toBe("Unknown variables: \"q11, q12, q13\".");
 
   const requiredIfQuestion = propertyGrid.survey.getQuestionByName("requiredIf");
   expect(requiredIfQuestion.errors).toHaveLength(1);


### PR DESCRIPTION
The expected error text in the "expression validation with multiple errors" test had to be updated because survey-core now flags self-comparisons like `{q2} = {q2}` as semantic errors (survey-library#11653). Since the property grid shows semantic errors with a higher priority than unknown-variable errors, the `visibleIf` expression `{q2} = {q2} = {q3}` now reports "Semantic error." instead of "Unknown variables: "q2, q3".".
