### PR TITLE
Translation tab, side-by-side mode: the element strings dialog shows …

### DIFF
--- a/e2e/designer/translation-side-by-side.spec.ts
+++ b/e2e/designer/translation-side-by-side.spec.ts
@@ -446,8 +446,10 @@ test.describe(title + " choices", () => {
     await page.locator(".st-side-by-side__target [data-name=q3] .svc-translation-state").click();
     const dialog = getStringsDialog(page);
     await expect(dialog).toBeVisible();
-    // The dialog is named by the element it translates.
-    await expect(dialog.locator(".sv-popup__body-header")).toHaveText("q3");
+    // The dialog is named by the element it translates: the caption row of its matrix, the
+    // row that carries the caption actions, and not a header of the dialog itself.
+    await expect(dialog.locator(".sv-popup__body-header")).toHaveCount(0);
+    await expect(dialog.locator(".st-element-strings .sd-question__title").first()).toHaveText(/q3/);
 
     // The used/all strings action offers the mode it switches to; Used Strings Only is the
     // default, so empty strings (the matrix has no description) are hidden until then.

--- a/e2e/designer/translation-side-by-side.spec.ts
+++ b/e2e/designer/translation-side-by-side.spec.ts
@@ -564,8 +564,10 @@ test.describe(title + " containers", () => {
     await target.locator(".sd-container-modern__title").locator(".svc-translation-state--untranslated").click();
     const dialog = getStringsDialog(page);
     await expect(dialog).toBeVisible();
-    // A survey without a title is named by the type name.
-    await expect(dialog.locator(".sv-popup__body-header")).toHaveText("Survey");
+    // A survey without a title is named by the type name, in the caption row of the matrix -
+    // the dialog carries no header of its own.
+    await expect(dialog.locator(".sv-popup__body-header")).toHaveCount(0);
+    await expect(dialog.locator(".st-element-strings .sd-question__title").first()).toHaveText(/Survey/);
     // Scoped to the survey-level strings - no rows of the nested elements.
     await expect(dialog.locator("table tr").filter({ hasText: "Question 1" })).toHaveCount(0);
     const row = dialog.locator("table tr").filter({ hasText: "Survey description" });

--- a/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation-plugin.ts
@@ -7,7 +7,7 @@ import { Translation, TranslationBase, createImportCSVAction, createExportCSVAct
 import { TranslationSideBySide } from "./translation-side-by-side";
 import { TabControlModel } from "../side-bar/tab-control-model";
 import { isDefaultLocale } from "../../survey-helper";
-import { createPageSelectorLocTitle } from "../../utils/actions";
+import { createPageSelectorLocTitle, createReadOnlyLocString } from "../../utils/actions";
 
 export class TabTranslationPlugin implements ICreatorPlugin {
   private filterStringsAction: Action;
@@ -491,7 +491,7 @@ export class TabTranslationPlugin implements ICreatorPlugin {
     this.filterPageAction.locTitle = !!page ? this.createPageLocTitle(page) : this.createAllPagesLocTitle();
   }
   private createAllPagesLocTitle(): LocalizableString {
-    const locTitle = new LocalizableString(this.creator.survey);
+    const locTitle = createReadOnlyLocString(this.creator.survey);
     locTitle.onGetTextCallback = (): string => this.showAllPagesText;
     return locTitle;
   }

--- a/packages/survey-creator-core/src/components/tabs/translation-side-by-side.ts
+++ b/packages/survey-creator-core/src/components/tabs/translation-side-by-side.ts
@@ -1,6 +1,6 @@
 import {
   Action, AdaptiveActionContainer, Base, DomDocumentHelper, EventBase, Helpers, IDialogOptions, ILocalizableString,
-  ItemValue, LocalizableString, PageModel, PanelModel, PopupBaseViewModel, Question,
+  ILocalizableOwner, ItemValue, LocalizableString, PageModel, PanelModel, PopupBaseViewModel, Question,
   QuestionCommentModel, QuestionDropdownModel,
   QuestionMatrixDropdownModel, Serializer, SurveyModel, property,
   settings as surveySettings, surveyLocalization
@@ -1396,7 +1396,9 @@ export class TranslationSideBySide extends TranslationBase implements ITranslati
       onApply: (): boolean => true,
       onHide: () => this.onElementStringsDialogHidden(model),
       cssClass: "svc-property-editor st-translation-dialog st-element-strings-dialog svc-creator-popup",
-      title: this.getElementStringsDialogTitle(realObj),
+      // No dialog title: the element the dialog edits is named by the caption row of the strings
+      // matrix, which renders it as a survey element title does - markdown included (a dialog
+      // title is a plain text). See createStringsMatrix.
       displayMode: this.options.isMobileView ? "overlay" : "popup"
     }, this.options.rootElement);
     this.elementStringsPopup = popup;
@@ -1407,13 +1409,6 @@ export class TranslationSideBySide extends TranslationBase implements ITranslati
     actions[0].title = editorLocalization.getString("pe.doneEditing");
     popup.locale = editorLocalization.locale;
     surveyLocalization.currentLocale = prevLocale;
-  }
-  private getElementStringsDialogTitle(obj: Base): string {
-    if (obj === <Base>this.survey) {
-      return this.survey.title || editorLocalization.getString("ed.surveyTypeName");
-    }
-    // A question's title falls back to its name by itself; pages and panels need the explicit one.
-    return (<any>obj).title || (<any>obj).name;
   }
   // The dialog is gone - by its own button or because the model closed it. A dialog that has
   // already been replaced by a newer one reports here as well, and its model is not the open one.
@@ -1556,6 +1551,16 @@ export class TranslationElementStrings extends TranslationBase {
   public get element(): Base {
     return this.elementValue;
   }
+  // The name the caption row shows: the title of the element the dialog edits, in the language
+  // it is translated from. A question's title falls back to its name by itself; pages and panels
+  // need the explicit one, and the survey falls back to its type name.
+  public get elementTitle(): string {
+    const element = <any>this.element;
+    if (element === <any>this.survey) {
+      return this.survey.title || editorLocalization.getString("ed.surveyTypeName");
+    }
+    return element.title || element.name;
+  }
   // Set by the owner - the all/used strings choice is kept for the next element.
   public onShowAllStringsChanged: (value: boolean) => void;
   // The caption row's actions - the title actions of the strings matrix: auto-translate (when
@@ -1605,11 +1610,11 @@ export class TranslationElementStrings extends TranslationBase {
     const matrix = <QuestionMatrixDropdownModel>Serializer.createClass("matrixdropdown");
     matrix.name = name;
     matrix.cellType = "comment";
-    // The matrix has no caption text: the dialog's own title names the element it belongs to.
-    // The title row itself stays - it is what carries the caption's actions - but it renders
-    // empty, without the question name a title-less question would fall back to.
+    // The title row is the caption row: it names the element the dialog edits and carries the
+    // caption's actions. The name is a survey element title here, so it renders the way the
+    // element's own title does, markdown included (see setupStringsMatrix).
     matrix.titleLocation = "top";
-    matrix.locTitle.onGetTextCallback = (): string => "";
+    matrix.locTitle.onGetTextCallback = (): string => this.elementTitle;
     // The header row names the two languages the columns edit, as the grid view's header row
     // does; the column of the string names has no header there either.
     matrix.showHeader = true;
@@ -1773,6 +1778,16 @@ export class TranslationElementStrings extends TranslationBase {
   private hostSurvey: SurveyModel;
   public setupStringsMatrix(survey: SurveyModel): void {
     this.hostSurvey = survey;
+    // The caption names the element, so it renders as the element's own title does: through the
+    // markdown event of the survey being translated - the one an application registers its
+    // markdown on. The dialog's survey is the creator's own and knows nothing of it.
+    survey.onTextMarkdown.add((_, options) => {
+      if (options.element !== this.stringsMatrix || options.name !== "title") return;
+      const html = (<ILocalizableOwner><any>this.element).getMarkdownHtml(options.text, options.name);
+      if (!!html) {
+        options.html = html;
+      }
+    });
     survey.onMatrixCellCreated.add(this.onMatrixCellCreated);
     survey.onMatrixCellValueChanging.add(this.onMatrixCellValueChanging);
     survey.onMatrixCellValueChanged.add(this.onMatrixCellValueChanged);

--- a/packages/survey-creator-core/src/components/tabs/translation.scss
+++ b/packages/survey-creator-core/src/components/tabs/translation.scss
@@ -432,7 +432,8 @@ td.st-table__cell:first-of-type {
 // The strings matrix of the dialog: its title row is the caption row, and its title actions are
 // the caption's buttons (auto-translate, all/used strings).
 .st-element-strings {
-  // The caption row holds no text - its buttons end it, at the dialog's right edge.
+  // The caption row names the element the dialog edits; its buttons end the row, at the
+  // dialog's right edge.
   .sd-action-title-bar {
     margin-left: auto;
   }

--- a/packages/survey-creator-core/src/utils/actions.ts
+++ b/packages/survey-creator-core/src/utils/actions.ts
@@ -7,7 +7,8 @@ import {
   property,
   CssClassBuilder,
   PageModel,
-  LocalizableString
+  LocalizableString,
+  ILocalizableOwner
 } from "survey-core";
 
 export function findAction(actions: Array<IAction>, id: string): IAction {
@@ -74,12 +75,28 @@ export function updateMatixActionsAppearance(actions: Array<IAction>) {
     removeRowAction.appearance = { style: "alert", mode: "quaternary", size: "small" };
   }
 }
+// A localizable string owned by an element of the edited survey is rendered by the creator's
+// inplace string editor (see getRendererForString in creator-base): the editor swaps the
+// rendered markdown for the source text as soon as it gets the focus, and a string shown in a
+// toolbar or in a dropdown is never edited there. This owner keeps the locale and the markdown
+// of the original owner and renders the string as a usual one.
+class ReadOnlyLocalizableOwner implements ILocalizableOwner {
+  constructor(private owner: ILocalizableOwner) { }
+  getLocale(): string { return this.owner.getLocale(); }
+  getMarkdownHtml(text: string, name: string, item?: any): string { return this.owner.getMarkdownHtml(text, name, item); }
+  getProcessedText(text: string): string { return this.owner.getProcessedText(text); }
+  getRenderer(): string { return undefined; }
+  getRendererContext(locStr: LocalizableString): any { return locStr; }
+}
+export function createReadOnlyLocString(owner: ILocalizableOwner, useMarkdown: boolean = false): LocalizableString {
+  return new LocalizableString(new ReadOnlyLocalizableOwner(owner), useMarkdown);
+}
 // Page titles support markdown, so a page selector item (the preview and the translation tabs)
-// shows its title via a localizable string owned by the page - this is what applies the survey
-// onTextMarkdown callback to the title. getDisplayText converts the title text of the current
-// locale into the text to show, an empty title included.
+// shows its title via a localizable string that takes the markdown of the page - this is what
+// applies the survey onTextMarkdown callback to the title. getDisplayText converts the title
+// text of the current locale into the text to show, an empty title included.
 export function createPageSelectorLocTitle(page: PageModel, getDisplayText: (text: string) => string): LocalizableString {
-  const locTitle = new LocalizableString(page, true);
+  const locTitle = createReadOnlyLocString(page, true);
   locTitle.setJson(page.locTitle.getJson());
   locTitle.onGetTextCallback = (text: string): string => getDisplayText(text);
   return locTitle;

--- a/packages/survey-creator-core/tests/tabs/translation-side-by-side.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation-side-by-side.tests.ts
@@ -1,6 +1,6 @@
 import {
   AdaptiveActionContainer, ItemValue, ListModel, QuestionCheckboxModel, QuestionCommentModel,
-  QuestionDropdownModel, QuestionMatrixDropdownModel, QuestionTextModel, settings as surveySettings
+  LocalizableString, QuestionDropdownModel, QuestionMatrixDropdownModel, QuestionTextModel, settings as surveySettings
 } from "survey-core";
 import { QuestionLinkValueModel } from "../../src/components/link-value";
 import {
@@ -13,6 +13,8 @@ import { TabTranslationPlugin } from "../../src/components/tabs/translation-plug
 import { StringEditorViewModelBase } from "../../src/components/string-editor";
 import { CreatorTester } from "../creator-tester";
 import "survey-core/survey.i18n";
+
+const defaultStringRenderer = LocalizableString.defaultRenderer;
 
 const sideBySideJSON = {
   locale: "de",
@@ -667,9 +669,8 @@ test("element strings dialog: a matrix over the real question, its own survey, e
   expect(model.elementStringsSurvey.getAllQuestions()).toHaveLength(1);
   const stringsMatrix = getStringsMatrix(model);
   expect(stringsMatrix.getType()).toBe("matrixdropdown");
-  // No caption text: the dialog's own title names the element. The title row itself stays -
-  // it carries the caption's actions.
-  expect(stringsMatrix.locTitle.renderedHtml).toBe("");
+  // The caption row names the element the dialog edits, and it carries the caption's actions.
+  expect(stringsMatrix.locTitle.renderedHtml).toBe("q3");
   expect(stringsMatrix.hasTitle).toBeTruthy();
   // The matrix's styles are scoped to its own class.
   expect(stringsMatrix.cssClasses.mainRoot).toContain("st-element-strings");
@@ -1506,7 +1507,10 @@ test("element strings dialog: shown as a modal over the element's own survey, wi
     // The dialog renders the model's own survey through the component every UI package registers.
     expect(options.componentName).toBe("survey-widget");
     expect(options.data.model).toBe(model.elementStringsSurvey);
-    expect(options.title).toBe("Question 1");
+    // The dialog carries no title of its own: the element it edits is named by the caption
+    // row of the strings matrix, which renders it as a survey element title does.
+    expect(options.title).toBeUndefined();
+    expect(getStringsMatrix(model).locTitle.renderedHtml).toBe("Question 1");
     expect(options.cssClass).toContain("st-element-strings-dialog");
     // The edits apply immediately: the apply/cancel pair is replaced by one closing button.
     expect(dialogs[0].footerToolbar.actions).toHaveLength(1);
@@ -1521,11 +1525,11 @@ test("element strings dialog: shown as a modal over the element's own survey, wi
     expect(stringsSurvey.isDisposed).toBeTruthy();
     // The pages, the panels and the survey itself are named by their title as well.
     model.showPageStringsDialog(model.targetSurvey.getPageByName("page2"));
-    expect(dialogs[1].options.title).toBe("Page 2 title");
+    expect(getStringsMatrix(model).locTitle.renderedHtml).toBe("Page 2 title");
     model.showPanelStringsDialog(<any>model.targetSurvey.getPanelByName("panel1"));
-    expect(dialogs[2].options.title).toBe("Panel 1");
+    expect(getStringsMatrix(model).locTitle.renderedHtml).toBe("Panel 1");
     model.showSurveyStringsDialog();
-    expect(dialogs[3].options.title).toBe("Survey title");
+    expect(getStringsMatrix(model).locTitle.renderedHtml).toBe("Survey title");
   });
 });
 
@@ -2150,4 +2154,59 @@ test("pages dropdown renders page titles with markdown, as the preview tab page 
   expect(filterPageAction.locTitle?.textOrHtml).toBe("<i>Page 1</i>#markup");
   getModel(creator).selectedPageName = "page2";
   expect(filterPageAction.locTitle?.textOrHtml).toBe("<i>Page 2</i>#markup");
+});
+
+test("pages dropdown shows page titles, it does not edit them: no inplace string editor", () => {
+  const creator = new CreatorTester({ showTranslationTab: true, translationMode: "sideBySide" });
+  creator.JSON = {
+    pages: [
+      { name: "page1", title: "Page 1", elements: [{ type: "text", name: "q1" }] },
+      { name: "page2", title: "Page 2", elements: [{ type: "text", name: "q2" }] }
+    ]
+  };
+  creator.activeTab = "translation";
+  const filterPageAction = creator.toolbar.getActionById("svc-translation-filter-page");
+  const items = getListItems(creator, "svc-translation-filter-page");
+  // The pages belong to the designer survey, which renders its own strings with the inplace
+  // editor - the editor replaces the rendered markdown with the source text once focused.
+  expect(items.map(item => item.locTitle?.renderAs)).toEqual([defaultStringRenderer, defaultStringRenderer]);
+  expect(filterPageAction.locTitle?.renderAs).toBe(defaultStringRenderer);
+  getModel(creator).selectedPageName = "page2";
+  expect(filterPageAction.locTitle?.renderAs).toBe(defaultStringRenderer);
+});
+
+test("element strings dialog: the caption row names the element, with the markdown of the edited survey", () => {
+  const creator = new CreatorTester({ showTranslationTab: true, translationMode: "sideBySide" });
+  creator.onSurveyInstanceSetupHandlers.add((sender, options) => {
+    if (options.area === "designer-tab") {
+      options.survey.onTextMarkdown.add((_, mdOptions) => {
+        mdOptions.html = mdOptions.text + "#markup";
+      });
+    }
+  });
+  creator.JSON = {
+    locale: "de",
+    title: "Survey title",
+    pages: [{
+      name: "page1", title: "Page 1",
+      elements: [{ type: "text", name: "q1", title: "Question 1" }, { type: "text", name: "q2" }]
+    }]
+  };
+  creator.activeTab = "translation";
+  const model = getModel(creator);
+  // The dialog has no title of its own: the element it edits is named by the caption row of the
+  // strings matrix, and the markdown comes from the survey being translated - the dialog's own
+  // survey carries no markdown handler of the application.
+  const getCaption = (element: any): string => {
+    model.showElementStringsDialog(element);
+    const caption = getStringsMatrix(model).locTitle.textOrHtml;
+    model.hideElementStringsDialog();
+    return caption;
+  };
+  const survey = creator.survey;
+  expect(getCaption(survey)).toBe("Survey title#markup");
+  expect(getCaption(survey.pages[0])).toBe("Page 1#markup");
+  expect(getCaption(survey.getQuestionByName("q1"))).toBe("Question 1#markup");
+  // A question with no title of its own is named by its name, as it is everywhere else.
+  expect(getCaption(survey.getQuestionByName("q2"))).toBe("q2#markup");
 });

--- a/packages/survey-creator-core/tests/tabs/translation.tests.ts
+++ b/packages/survey-creator-core/tests/tabs/translation.tests.ts
@@ -1,4 +1,4 @@
-import { Serializer, SurveyModel, surveyLocalization, Base, QuestionDropdownModel, PanelModel, QuestionMatrixDropdownModel, QuestionTextModel, QuestionCommentModel, ListModel, Action, IAction, ItemValue, QuestionMatrixDynamicModel, QuestionMatrixModel, settings as coreSettings } from "survey-core";
+import { Serializer, SurveyModel, surveyLocalization, Base, QuestionDropdownModel, PanelModel, QuestionMatrixDropdownModel, QuestionTextModel, QuestionCommentModel, ListModel, LocalizableString, Action, IAction, ItemValue, QuestionMatrixDynamicModel, QuestionMatrixModel, settings as coreSettings } from "survey-core";
 import { Translation, TranslationItem } from "../../src/components/tabs/translation";
 import { TabTranslationPlugin } from "../../src/components/tabs/translation-plugin";
 import { EmptySurveyCreatorOptions, settings } from "../../src/creator-settings";
@@ -3094,4 +3094,28 @@ test("Page filter dropdown renders page titles with markdown, as the preview tab
 
   tabTranslationPlugin.model.filteredPage = null;
   expect(filterPageAction.locTitle?.textOrHtml).toEqual("All Pages");
+});
+
+test("Page filter dropdown shows page titles, it does not edit them: no inplace string editor", () => {
+  const creator = new CreatorTester();
+  creator.JSON = {
+    pages: [
+      { name: "page1", title: "Page 1", elements: [{ type: "text", name: "q1" }] },
+      { name: "page2", title: "Page 2", elements: [{ type: "text", name: "q2" }] }
+    ]
+  };
+  const tabTranslationPlugin = new TabTranslationPlugin(creator);
+  tabTranslationPlugin.activate();
+  const filterPageAction = tabTranslationPlugin["filterPageAction"];
+  const filterPageList = <ListModel>(filterPageAction.data);
+  // The pages and the survey belong to the designer survey, which renders its own strings with
+  // the inplace editor - the editor replaces the rendered markdown with the source text once
+  // focused.
+  const defaultRenderer = LocalizableString.defaultRenderer;
+  expect(filterPageList.actions.map(item => item.locTitle?.renderAs))
+    .toEqual([defaultRenderer, defaultRenderer, defaultRenderer]);
+  expect(filterPageAction.locTitle?.renderAs).toEqual(defaultRenderer);
+
+  tabTranslationPlugin.model.filteredPage = creator.survey.pages[1];
+  expect(filterPageAction.locTitle?.renderAs).toEqual(defaultRenderer);
 });


### PR DESCRIPTION
…the element title as a raw markup fix #7989